### PR TITLE
docs: fix `lookup` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ router.insert('/path/foo/**', { payload: 'wildcard route' })
 
 ```js
 // { payload: 'this path' }
-router.lookup('/test')
+router.lookup('/path')
 
 // { payload: 'named route', params: { name: 'fooval' } }
-router.lookup('/test/fooval')
+router.lookup('/path/fooval')
 
 // { payload: 'wildcard route' }
 router.lookup('/path/foo/bar/baz')


### PR DESCRIPTION
With the example provided, it seems to indicate that the inserted `/path` is going to match with `/test` on the lookup. 

I can only assume this is a typo, as these routes don't match 