### PR TITLE
fix: allow type checking to work with native Node16 Typescript ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,11 @@
   "sideEffects": false,
   "type": "module",
   "exports": {
-    "require": "./dist/index.cjs",
-    "import": "./dist/index.mjs"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.mjs"
+    }
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
With the introduction of [Typescript 4.7](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/) native ESM support for Node is officially available when using the `Node16` `"module"` and `"moduleResolution"` options. This, however, requires a small change in the `package.json` `"exports"` field to allow types to flow through correctly as documented [here](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing).

This PR makes that small change.