### PR TITLE
feat: route matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Remove route matching `path`.
 
 ### Route Matcher
 
-**Experimental feature:** Behavior might change in a semver-minor release]
+**Experimental feature:** Behavior might change in a semver-minor release.
 
 Creates a multi matcher from router tree that can match **all routes** matching path:
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Remove route matching `path`.
 Creates a multi matcher from router tree that can match **all routes** matching path:
 
 ```ts
-import { createRouter, toMatcher } from 'radix3'
+import { createRouter, toRouteMatcher } from 'radix3'
 
 const router = createRouter({
   routes: {
@@ -99,7 +99,7 @@ const router = createRouter({
   }
 })
 
-const matcher = toMatcher(router)
+const matcher = toRouteMatcher(router)
 
 const matches = matcher.matchAll('/foo/bar/baz')
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # 🌳 radix3
 
 [![npm version][npm-version-src]][npm-version-href]
@@ -80,6 +79,42 @@ Find all data nodes matching path prefix.
 ### `router.remove(path)`
 
 Remove route matching `path`.
+
+### Route Matcher
+
+**Experimental feature:** Behavior might change in a semver-minor release]
+
+Creates a multi matcher from router tree that can match **all routes** matching path:
+
+```ts
+import { createRouter, toMatcher } from 'radix3'
+
+const router = createRouter({
+  routes: {
+    '/foo': { m: 'foo' }, // Matches /foo only
+    '/foo/**': { m: 'foo/**' }, // Matches /foo/<any>
+    '/foo/bar': { m: 'foo/bar' },  // Matches /foo/bar only
+    '/foo/bar/baz': { m: 'foo/bar/baz' }, // Matches /foo/bar/baz only
+    '/foo/*/baz': { m: 'foo/*/baz' } // Matches /foo/<any>/baz
+  }
+})
+
+const matcher = toMatcher(router)
+
+const matches = matcher.matchAll('/foo/bar/baz')
+
+// [
+//   {
+//     "m": "foo/**",
+//   },
+//   {
+//     "m": "foo/*/baz",
+//   },
+//   {
+//     "m": "foo/bar/baz",
+//   },
+// ]
+```
 
 ## Performance
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
 export * from './router'
+export * from './matcher'
+
 export * from './types'

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -11,7 +11,7 @@ export interface RouteMatcher {
   matchAll: (path: string) => RadixNodeData[]
 }
 
-export function toMatcher (router: RadixRouter): RouteMatcher {
+export function toRouteMatcher (router: RadixRouter): RouteMatcher {
   const table = _routerNodeToTable('', router.ctx.rootNode)
   return _createMatcher(table)
 }

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -1,0 +1,72 @@
+import { RadixNode, RadixRouter, NODE_TYPES } from './types'
+
+export type RouteData = any
+
+export interface RouteTable {
+  static: Map<string, RouteData>
+  wildcard: Map<string, RouteData>
+  dynamic: Map<string, RouteTable>
+}
+
+export function createRouteMatcher (router: RadixRouter) {
+  const table = createRouteTable('', router.ctx.rootNode)
+  return {
+    ctx: { table },
+    match: path => matchRoutes(path, table)
+  }
+}
+
+function matchRoutes (path: string, table: RouteData): RouteData[] {
+  const matches = []
+
+  // Wildcard
+  for (const [key, value] of table.wildcard) {
+    if (path.startsWith(key)) {
+      matches.push(value)
+    }
+  }
+
+  // Dynamic
+  for (const [key, value] of table.dynamic) {
+    if (path.startsWith(key)) {
+      const subPath = '/' + path.substring(key.length).split('/').splice(2).join('/')
+      matches.push(...matchRoutes(subPath, value))
+    }
+  }
+
+  // Static
+  const staticMatch = table.static.get(path)
+  if (staticMatch) {
+    matches.push(staticMatch)
+  }
+
+  return matches.filter(Boolean)
+}
+
+function createRouteTable (initialPath: string, initialNode: RadixNode): RouteTable {
+  const table: RouteTable = {
+    static: new Map(),
+    wildcard: new Map(),
+    dynamic: new Map()
+  }
+
+  const addNode = (path: string, node: RadixNode) => {
+    if (path) {
+      if (node.type === NODE_TYPES.NORMAL && !path.includes('*')) {
+        table.static.set(path, node.data)
+      } else if (node.type === NODE_TYPES.WILDCARD) {
+        table.wildcard.set(path.replace('/**', ''), node.data)
+      } else if (node.type === NODE_TYPES.PLACEHOLDER) {
+        table.dynamic.set(path.replace('/*', ''), createRouteTable('', node))
+        return
+      }
+    }
+    for (const [childPath, child] of node.children.entries()) {
+      addNode(`${path}/${childPath}`.replace('//', '/'), child)
+    }
+  }
+
+  addNode(initialPath, initialNode)
+
+  return table
+}

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -58,14 +58,16 @@ function _routerNodeToTable (initialPath: string, initialNode: RadixNode): Route
   const table: RouteTable = _createRouteTable()
   function _addNode (path: string, node: RadixNode) {
     if (path) {
-      if (node.type === NODE_TYPES.NORMAL && !(path.includes('*'))) {
+      if (node.type === NODE_TYPES.NORMAL && !(path.includes('*') || path.includes(':'))) {
         table.static.set(path, node.data)
       } else if (node.type === NODE_TYPES.WILDCARD) {
         table.wildcard.set(path.replace('/**', ''), node.data)
       } else if (node.type === NODE_TYPES.PLACEHOLDER) {
         const subTable = _routerNodeToTable('', node)
-        subTable.static.set('/', node.data)
-        table.dynamic.set(path.replace('/*', ''), subTable)
+        if (node.data) {
+          subTable.static.set('/', node.data)
+        }
+        table.dynamic.set(path.replace(/\/\*|\/:\w+/, ''), subTable)
         return
       }
     }

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -28,7 +28,7 @@ function matchRoutes (path: string, table: RouteData): RouteData[] {
 
   // Dynamic
   for (const [key, value] of table.dynamic) {
-    if (path.startsWith(key)) {
+    if (path.startsWith(key + '/')) {
       const subPath = '/' + path.substring(key.length).split('/').splice(2).join('/')
       matches.push(...matchRoutes(subPath, value))
     }
@@ -57,7 +57,9 @@ function createRouteTable (initialPath: string, initialNode: RadixNode): RouteTa
       } else if (node.type === NODE_TYPES.WILDCARD) {
         table.wildcard.set(path.replace('/**', ''), node.data)
       } else if (node.type === NODE_TYPES.PLACEHOLDER) {
-        table.dynamic.set(path.replace('/*', ''), createRouteTable('', node))
+        const subtable = createRouteTable('', node)
+        subtable.static.set('/', node.data)
+        table.dynamic.set(path.replace('/*', ''), subtable)
         return
       }
     }

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -1,74 +1,78 @@
-import { RadixNode, RadixRouter, NODE_TYPES } from './types'
-
-export type RouteData = any
+import { RadixNode, RadixRouter, RadixNodeData, NODE_TYPES } from './types'
 
 export interface RouteTable {
-  static: Map<string, RouteData>
-  wildcard: Map<string, RouteData>
+  static: Map<string, RadixNodeData>
+  wildcard: Map<string, RadixNodeData>
   dynamic: Map<string, RouteTable>
 }
 
-export function createRouteMatcher (router: RadixRouter) {
-  const table = createRouteTable('', router.ctx.rootNode)
-  return {
+export interface RouteMatcher {
+  ctx: { table: RouteTable }
+  match: (path: string) => RadixNodeData[]
+}
+
+export function routerToMatcher (router: RadixRouter): RouteMatcher {
+  const table = _routerNodeToTable('', router.ctx.rootNode)
+  return _createMatcher(table)
+}
+
+function _createMatcher (table: RouteTable): RouteMatcher {
+  return <RouteMatcher> {
     ctx: { table },
-    match: path => matchRoutes(path, table)
+    match: path => _matchRoutes(path, table)
   }
 }
 
-function matchRoutes (path: string, table: RouteData): RouteData[] {
-  const matches = []
+function _createRouteTable (): RouteTable {
+  return <RouteTable>{
+    static: new Map(),
+    wildcard: new Map(),
+    dynamic: new Map()
+  }
+}
 
+function _matchRoutes (path: string, table: RouteTable): RadixNodeData[] {
+  const matches = []
   // Wildcard
   for (const [key, value] of table.wildcard) {
     if (path.startsWith(key)) {
       matches.push(value)
     }
   }
-
   // Dynamic
   for (const [key, value] of table.dynamic) {
     if (path.startsWith(key + '/')) {
       const subPath = '/' + path.substring(key.length).split('/').splice(2).join('/')
-      matches.push(...matchRoutes(subPath, value))
+      matches.push(..._matchRoutes(subPath, value))
     }
   }
-
   // Static
   const staticMatch = table.static.get(path)
   if (staticMatch) {
     matches.push(staticMatch)
   }
-
   return matches.filter(Boolean)
 }
 
-function createRouteTable (initialPath: string, initialNode: RadixNode): RouteTable {
-  const table: RouteTable = {
-    static: new Map(),
-    wildcard: new Map(),
-    dynamic: new Map()
-  }
-
-  const addNode = (path: string, node: RadixNode) => {
+function _routerNodeToTable (initialPath: string, initialNode: RadixNode): RouteTable {
+  const table: RouteTable = _createRouteTable()
+  function _addNode (path: string, node: RadixNode) {
     if (path) {
-      if (node.type === NODE_TYPES.NORMAL && !path.includes('*')) {
+      if (node.type === NODE_TYPES.NORMAL && !(path.includes('*'))) {
         table.static.set(path, node.data)
       } else if (node.type === NODE_TYPES.WILDCARD) {
         table.wildcard.set(path.replace('/**', ''), node.data)
       } else if (node.type === NODE_TYPES.PLACEHOLDER) {
-        const subtable = createRouteTable('', node)
-        subtable.static.set('/', node.data)
-        table.dynamic.set(path.replace('/*', ''), subtable)
+        const subTable = _routerNodeToTable('', node)
+        subTable.static.set('/', node.data)
+        table.dynamic.set(path.replace('/*', ''), subTable)
         return
       }
     }
     for (const [childPath, child] of node.children.entries()) {
-      addNode(`${path}/${childPath}`.replace('//', '/'), child)
+      _addNode(`${path}/${childPath}`.replace('//', '/'), child)
     }
   }
-
-  addNode(initialPath, initialNode)
-
+  _addNode(initialPath, initialNode)
   return table
 }

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -8,10 +8,10 @@ export interface RouteTable {
 
 export interface RouteMatcher {
   ctx: { table: RouteTable }
-  match: (path: string) => RadixNodeData[]
+  matchAll: (path: string) => RadixNodeData[]
 }
 
-export function routerToMatcher (router: RadixRouter): RouteMatcher {
+export function toMatcher (router: RadixRouter): RouteMatcher {
   const table = _routerNodeToTable('', router.ctx.rootNode)
   return _createMatcher(table)
 }
@@ -19,7 +19,7 @@ export function routerToMatcher (router: RadixRouter): RouteMatcher {
 function _createMatcher (table: RouteTable): RouteMatcher {
   return <RouteMatcher> {
     ctx: { table },
-    match: path => _matchRoutes(path, table)
+    matchAll: path => _matchRoutes(path, table)
   }
 }
 

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -20,7 +20,19 @@ describe('Route matcher', function () {
     const matcher = toRouteMatcher(router)
     const matches = matcher.matchAll('/foo/bar/baz')
 
-    expect(JSON.stringify(matches)).to.toMatchInlineSnapshot('"[{\\"m\\":\\"foo/**\\"},{\\"m\\":\\"foo/*/baz\\"},{\\"m\\":\\"foo/bar/baz\\"}]"')
+    expect(matches).to.toMatchInlineSnapshot(`
+      [
+        {
+          "m": "foo/**",
+        },
+        {
+          "m": "foo/*/baz",
+        },
+        {
+          "m": "foo/bar/baz",
+        },
+      ]
+    `)
   })
 
   const routes = createRoutes([

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { createRouter, createRouteMatcher } from '../src'
+
+export function createRoutes (paths) {
+  return Object.fromEntries(paths.map(path => [path, { pattern: path }]))
+}
+
+describe('Route matcher', function () {
+  const router = createRouter({
+    routes: createRoutes([
+      '/',
+      '/foo',
+      '/foo/*',
+      '/foo/**',
+      '/foo/bar',
+      '/foo/baz',
+      '/foo/baz/**',
+      '/foo/*/baz'
+    ])
+  })
+
+  const matcher = createRouteMatcher(router)
+
+  const _match = path => matcher.match(path).map(r => r.pattern)
+
+  it('can create route table', () => {
+    expect(matcher.ctx.table).to.toMatchInlineSnapshot(`
+      {
+        "dynamic": Map {
+          "/foo" => {
+            "dynamic": Map {},
+            "static": Map {
+              "/baz" => {
+                "pattern": "/foo/*/baz",
+              },
+            },
+            "wildcard": Map {},
+          },
+        },
+        "static": Map {
+          "/" => {
+            "pattern": "/",
+          },
+          "/foo" => {
+            "pattern": "/foo",
+          },
+          "/foo/bar" => {
+            "pattern": "/foo/bar",
+          },
+          "/foo/baz" => {
+            "pattern": "/foo/baz",
+          },
+        },
+        "wildcard": Map {
+          "/foo" => {
+            "pattern": "/foo/**",
+          },
+          "/foo/baz" => {
+            "pattern": "/foo/baz/**",
+          },
+        },
+      }
+    `)
+  })
+
+  it('can match routes', () => {
+    expect(_match('/')).to.toMatchInlineSnapshot(`
+      [
+        "/",
+      ]
+    `)
+    expect(_match('/foo')).to.toMatchInlineSnapshot(`
+      [
+        "/foo/**",
+        "/foo",
+      ]
+    `)
+    expect(_match('/foo/bar')).to.toMatchInlineSnapshot(`
+      [
+        "/foo/**",
+        "/foo/bar",
+      ]
+    `)
+    expect(_match('/foo/xyz/baz')).to.toMatchInlineSnapshot(`
+      [
+        "/foo/**",
+        "/foo/*/baz",
+      ]
+    `)
+    // TODO
+    expect(_match('/foo/xyz')).to.toMatchInlineSnapshot(`
+    [
+      "/foo/**",
+    ]
+  `)
+  })
+})

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -1,25 +1,24 @@
 import { describe, it, expect } from 'vitest'
-import { createRouter, createRouteMatcher } from '../src'
+import { createRouter, routerToMatcher } from '../src'
 
 export function createRoutes (paths) {
   return Object.fromEntries(paths.map(path => [path, { pattern: path }]))
 }
 
 describe('Route matcher', function () {
-  const router = createRouter({
-    routes: createRoutes([
-      '/',
-      '/foo',
-      '/foo/*',
-      '/foo/**',
-      '/foo/bar',
-      '/foo/baz',
-      '/foo/baz/**',
-      '/foo/*/sub'
-    ])
-  })
+  const routes = createRoutes([
+    '/',
+    '/foo',
+    '/foo/*',
+    '/foo/**',
+    '/foo/bar',
+    '/foo/baz',
+    '/foo/baz/**',
+    '/foo/*/sub'
+  ])
 
-  const matcher = createRouteMatcher(router)
+  const router = createRouter({ routes })
+  const matcher = routerToMatcher(router)
 
   const _match = path => matcher.match(path).map(r => r.pattern)
 

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -1,11 +1,28 @@
 import { describe, it, expect } from 'vitest'
-import { createRouter, routerToMatcher } from '../src'
+import { createRouter, toMatcher } from '../src'
 
 export function createRoutes (paths) {
   return Object.fromEntries(paths.map(path => [path, { pattern: path }]))
 }
 
 describe('Route matcher', function () {
+  it('readme example works', () => {
+    const router = createRouter({
+      routes: {
+        '/foo': { m: 'foo' },
+        '/foo/**': { m: 'foo/**' },
+        '/foo/bar': { m: 'foo/bar' },
+        '/foo/bar/baz': { m: 'foo/bar/baz' },
+        '/foo/*/baz': { m: 'foo/*/baz' }
+      }
+    })
+
+    const matcher = toMatcher(router)
+    const matches = matcher.matchAll('/foo/bar/baz')
+
+    expect(JSON.stringify(matches)).to.toMatchInlineSnapshot('"[{\\"m\\":\\"foo/**\\"},{\\"m\\":\\"foo/*/baz\\"},{\\"m\\":\\"foo/bar/baz\\"}]"')
+  })
+
   const routes = createRoutes([
     '/',
     '/foo',
@@ -18,9 +35,9 @@ describe('Route matcher', function () {
   ])
 
   const router = createRouter({ routes })
-  const matcher = routerToMatcher(router)
+  const matcher = toMatcher(router)
 
-  const _match = path => matcher.match(path).map(r => r.pattern)
+  const _match = path => matcher.matchAll(path).map(r => r.pattern)
 
   it('can create route table', () => {
     expect(matcher.ctx.table).to.toMatchInlineSnapshot(`

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { createRouter, toMatcher } from '../src'
+import { createRouter, toRouteMatcher } from '../src'
 
 export function createRoutes (paths) {
   return Object.fromEntries(paths.map(path => [path, { pattern: path }]))
@@ -17,7 +17,7 @@ describe('Route matcher', function () {
       }
     })
 
-    const matcher = toMatcher(router)
+    const matcher = toRouteMatcher(router)
     const matches = matcher.matchAll('/foo/bar/baz')
 
     expect(JSON.stringify(matches)).to.toMatchInlineSnapshot('"[{\\"m\\":\\"foo/**\\"},{\\"m\\":\\"foo/*/baz\\"},{\\"m\\":\\"foo/bar/baz\\"}]"')
@@ -35,7 +35,7 @@ describe('Route matcher', function () {
   ])
 
   const router = createRouter({ routes })
-  const matcher = toMatcher(router)
+  const matcher = toRouteMatcher(router)
 
   const _match = path => matcher.matchAll(path).map(r => r.pattern)
 

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -15,7 +15,7 @@ describe('Route matcher', function () {
       '/foo/bar',
       '/foo/baz',
       '/foo/baz/**',
-      '/foo/*/baz'
+      '/foo/*/sub'
     ])
   })
 
@@ -30,8 +30,11 @@ describe('Route matcher', function () {
           "/foo" => {
             "dynamic": Map {},
             "static": Map {
-              "/baz" => {
-                "pattern": "/foo/*/baz",
+              "/sub" => {
+                "pattern": "/foo/*/sub",
+              },
+              "/" => {
+                "pattern": "/foo/*",
               },
             },
             "wildcard": Map {},
@@ -78,20 +81,29 @@ describe('Route matcher', function () {
     expect(_match('/foo/bar')).to.toMatchInlineSnapshot(`
       [
         "/foo/**",
+        "/foo/*",
         "/foo/bar",
       ]
     `)
-    expect(_match('/foo/xyz/baz')).to.toMatchInlineSnapshot(`
+    expect(_match('/foo/baz')).to.toMatchInlineSnapshot(`
       [
         "/foo/**",
-        "/foo/*/baz",
+        "/foo/baz/**",
+        "/foo/*",
+        "/foo/baz",
       ]
     `)
-    // TODO
-    expect(_match('/foo/xyz')).to.toMatchInlineSnapshot(`
-    [
-      "/foo/**",
-    ]
-  `)
+    expect(_match('/foo/123/sub')).to.toMatchInlineSnapshot(`
+      [
+        "/foo/**",
+        "/foo/*/sub",
+      ]
+    `)
+    expect(_match('/foo/123')).to.toMatchInlineSnapshot(`
+      [
+        "/foo/**",
+        "/foo/*",
+      ]
+    `)
   })
 })


### PR DESCRIPTION
The router is able to return one route quickly using radix3. For matching multiple routes, use a different data structure (prefix table similar to h3) that can match **all routes** matching path.

Note: Implementation might be improved in semver-minor with behavior changes. Also dependency on router (for radix3 joins) might be removed some point later which is why API is specifically called toMatcher

Note 2: Only * and ** are supported and tested. Named :foo params partially work (not for tree edges)

--- 

Creates a multi matcher from router tree that can match **all routes** matching path:

```ts
import { createRouter, toMatcher } from 'radix3'

const router = createRouter({
  routes: {
    '/foo': { m: 'foo' }, // Matches /foo only
    '/foo/**': { m: 'foo/**' }, // Matches /foo/<any>
    '/foo/bar': { m: 'foo/bar' },  // Matches /foo/bar only
    '/foo/bar/baz': { m: 'foo/bar/baz' }, // Matches /foo/bar/baz only
    '/foo/*/baz': { m: 'foo/*/baz' } // Matches /foo/<any>/baz
  }
})

const matcher = toMatcher(router)

const matches = matcher.matchAll('/foo/bar/baz')

// [
//   {
//     "m": "foo/**",
//   },
//   {
//     "m": "foo/*/baz",
//   },
//   {
//     "m": "foo/bar/baz",
//   },
// ]
```
