### PR TITLE
feat!: make strict trailing slash opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can initialize router instance with options:
 
 ```ts
 const router = createRouter({
-  strictTrailinSlash: true,
+  strictTrailingSlash: true,
   routes: {
     '/foo': {}
   }
@@ -95,7 +95,7 @@ const router = createRouter({
 ```
 
 - `routes`: An object specifying initial routes to add
-- `strictTrailinSlash`: If enabled (disabled by default) matcher makes differences for matching routes with trailing slash
+- `strictTrailingSlash`: If enabled (disabled by default) matcher makes differences for matching routes with trailing slash
 
 ### Route Matcher
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ const router = createRouter({
 ```
 
 - `routes`: An object specifying initial routes to add
-- `strictTrailingSlash`: If enabled (disabled by default) matcher makes differences for matching routes with trailing slash
+- `strictTrailingSlash`: By default router ignored trailing slash for matching and adding routes. When set to `true`, matching with trailing slash is different.
 
 ### Route Matcher
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ const { createRouter } = require('radix3')
 **Create a router instance and insert routes:**
 
 ```js
-const router = createRouter()
+const router = createRouter(/* options */)
 
 router.insert('/path', { payload: 'this path' })
 router.insert('/path/:name', { payload: 'named route' })
@@ -79,6 +79,23 @@ Find all data nodes matching path prefix.
 ### `router.remove(path)`
 
 Remove route matching `path`.
+
+## Options
+
+You can initialize router instance with options:
+
+```ts
+const router = createRouter({
+  strictTrailinSlash: true,
+  routes: {
+    '/foo': {}
+  }
+})
+
+```
+
+- `routes`: An object specifying initial routes to add
+- `strictTrailinSlash`: If enabled (disabled by default) matcher makes differences for matching routes with trailing slash
 
 ### Route Matcher
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,25 +1,28 @@
-import type { RadixRouterContext, RadixNode, MatchedRoute, RadixRouter, RadixNodeData, RadixRouterInitOptions } from './types'
+import type { RadixRouterContext, RadixNode, MatchedRoute, RadixRouter, RadixNodeData, RadixRouterOptions } from './types'
 import { NODE_TYPES } from './types'
 
-export function createRouter<T extends RadixNodeData = RadixNodeData> (options: RadixRouterInitOptions = {}): RadixRouter<T> {
+export function createRouter<T extends RadixNodeData = RadixNodeData> (options: RadixRouterOptions = {}): RadixRouter<T> {
   const ctx: RadixRouterContext = {
+    options,
     rootNode: createRadixNode(),
     staticRoutesMap: {}
   }
 
+  const normalizeTrailingSlash = p => options.strictTrailingSlash ? p : p.replace(/\/$/, '')
+
   if (options.routes) {
     for (const path in options.routes) {
-      insert(ctx, path, options.routes[path])
+      insert(ctx, normalizeTrailingSlash(path), options.routes[path])
     }
   }
 
   return {
     ctx,
     // @ts-ignore
-    lookup: (path: string) => lookup(ctx, path),
+    lookup: (path: string) => lookup(ctx, normalizeTrailingSlash(path)),
     lookupAll: (prefix: string) => lookupAll(ctx, prefix),
-    insert: (path: string, data: any) => insert(ctx, path, data),
-    remove: (path: string) => remove(ctx, path)
+    insert: (path: string, data: any) => insert(ctx, normalizeTrailingSlash(path), data),
+    remove: (path: string) => remove(ctx, normalizeTrailingSlash(path))
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,13 +21,15 @@ export interface RadixNode<T extends RadixNodeData = RadixNodeData> {
   placeholderChildNode: RadixNode<T> | null
 }
 
-export interface RadixRouterContext<T extends RadixNodeData = RadixNodeData> {
-  rootNode: RadixNode<T>
-  staticRoutesMap: Record<string, RadixNode>
+export interface RadixRouterOptions {
+  strictTrailingSlash?: boolean
+  routes?: Record<string, any>
 }
 
-export interface RadixRouterInitOptions {
-  routes?: Record<string, any>
+export interface RadixRouterContext<T extends RadixNodeData = RadixNodeData> {
+  options: RadixRouterOptions
+  rootNode: RadixNode<T>
+  staticRoutesMap: Record<string, RadixNode>
 }
 
 export interface RadixRouter<T extends RadixNodeData = RadixNodeData> {

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -43,8 +43,7 @@ describe('Router lookup', function () {
         }
       },
       '/carbon': null,
-      // TODO
-      // 'carbon/': null,
+      'carbon/': null,
       'carbon/test2/test/test23': {
         path: 'carbon/:element/test/:testing',
         params: {
@@ -92,10 +91,9 @@ describe('Router lookup', function () {
       'route/with/trailing/slash/'
     ], {
       'route/without/trailing/slash': { path: 'route/without/trailing/slash' },
-      'route/with/trailing/slash/': { path: 'route/with/trailing/slash/' }
-      // TODO
-      // 'route/without/trailing/slash/': { path: 'route/without/trailing/slash' },
-      // 'route/with/trailing/slash': { path: 'route/with/trailing/slash/' },
+      'route/with/trailing/slash/': { path: 'route/with/trailing/slash/' },
+      'route/without/trailing/slash/': { path: 'route/without/trailing/slash' },
+      'route/with/trailing/slash': { path: 'route/with/trailing/slash/' }
     })
   })
 })


### PR DESCRIPTION
Resolves #8

BREAKING CHANGE: Ignore trailing slash by default. can be enabled back by passing `strictTrailingSlash: true` to `createRouter` options.