### PR TITLE
Feat/added the possibility to add functions to match the route path

### DIFF
--- a/benchmark/utils.mjs
+++ b/benchmark/utils.mjs
@@ -32,8 +32,10 @@ export const router = createRouter({
     '/choot',
     '/choot/:choo',
     '/ui/**',
-    '/ui/components/**'
-  ].map(path => [path, { path }]))
+    '/ui/components/**',
+    '/::lang/international/**'
+  ].map(path => [path, { path }])),
+  funcs: { lang: str => str.length === 2 }
 })
 
 export const benchSets = [
@@ -47,6 +49,12 @@ export const benchSets = [
     title: 'dynamic route',
     requests: [
       { path: '/choot/123' }
+    ]
+  },
+  {
+    title: 'dynamic route with funcs',
+    requests: [
+      { path: '/it/international/some' }
     ]
   }
 ]

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,8 @@
 export const NODE_TYPES = {
   NORMAL: 0 as 0,
   WILDCARD: 1 as 1,
-  PLACEHOLDER: 2 as 2
+  PLACEHOLDER: 2 as 2,
+  CHECKED_PLACEHOLDER: 3 as 3
 }
 
 type _NODE_TYPES = typeof NODE_TYPES
@@ -19,17 +20,21 @@ export interface RadixNode<T extends RadixNodeData = RadixNodeData> {
   paramName: string | null
   wildcardChildNode: RadixNode<T> | null
   placeholderChildNode: RadixNode<T> | null
+  placeholderChildrenNodeChecked: Array<RadixNode<T>>
+  check: (str: string) => boolean
 }
 
 export interface RadixRouterOptions {
   strictTrailingSlash?: boolean
   routes?: Record<string, any>
+  funcs?: Record<string, (str: string) => boolean>
 }
 
 export interface RadixRouterContext<T extends RadixNodeData = RadixNodeData> {
   options: RadixRouterOptions
   rootNode: RadixNode<T>
   staticRoutesMap: Record<string, RadixNode>
+  funcs: Record<string, (str: string) => boolean>
 }
 
 export interface RadixRouter<T extends RadixNodeData = RadixNodeData> {
@@ -49,7 +54,7 @@ export interface RadixRouter<T extends RadixNodeData = RadixNodeData> {
    * @param data - the associated data to path
    *
   */
-  insert(path: string, data: T): void
+  insert(path: string, data: T, funcs?: { [key: string]: (((str: string) => boolean) | undefined) }): void
 
   /**
    * Perform a remove on the tree


### PR DESCRIPTION
Hi, I need the possibility to create a custom match of the path, so I created this new feature. 
This feature allows passing custom functions to match the path. I have also implemented the remove algorithm. 

## Feature 
The `createRouter` now takes as input a new parameter called `funcs`, of this type:
```ts 
Record<string, (str: string) => boolean>
```
and I added a new pattern in the routes: `::functionName`.

An example of the new `createRouter`:

```ts
createRouter({
     routes: {
         '::len/hello/two': { hello: 'world' },
         'st/hello/two': { word: 'hello'}
     },
     funcs: {
        len: (str) => str.length === 2,
     }
});
```
All routes having two characters as the first path match the first route, excluding the path `st`.
The matching priority is changed in:
1. static routes
2. function routes
3. placeholder
4. wildcard

WDYT about this feature?