### PR TITLE
fix: dynamic route deletion

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -150,7 +150,7 @@ function remove (ctx: RadixRouterContext, path: string) {
     node.data = null
     if (Object.keys(node.children).length === 0) {
       const parentNode = node.parent
-      delete parentNode[lastSection]
+      parentNode.children.delete(lastSection)
       parentNode.wildcardChildNode = null
       parentNode.placeholderChildNode = null
     }


### PR DESCRIPTION
The dynamic route deletion logic is not removing the children from parent's `children` map properly because of a typo.

# Steps to reporduce
```
router.insert('/path', { payload: 'this path' })
router.insert('/path/:name', { payload: 'named route' })
router.remove('/path/:name')
router.insert('/path/:name', { payload: 'named route' })
```

the dynamic route placeholder is not assigned to the parent node since it never get removed from the children map.