### PR TITLE
feat: URL filtering with `createFilter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,28 @@ const matches = matcher.matchAll('/foo/bar/baz')
 // ]
 ```
 
+### Route Filter
+
+Create a filter function to check if a route matches `include` and `exclude` route patterns:
+
+```ts
+import { createFilter } from 'radix3/utils'
+
+const filter = createFilter({
+  include: ['/admin/**', '/admin', /^\/_api\/\d*/],
+  exclude: ['/admin/login']
+})
+// Result: true
+filter('/admin')
+filter('/admin/users')
+filter('/_api/123')
+// Result: false
+filter('/admin/login')
+filter('/safe-url')
+filter('/page/admin')
+filter('/_api/abc')
+```
+
 ## Performance
 
 See [benchmark](./benchmark).

--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
       "types": "./dist/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.mjs"
+    },
+    "./utils": {
+      "types": "./dist/utils.d.ts",
+      "require": "./dist/utils.cjs",
+      "import": "./dist/utils.mjs"
     }
   },
   "main": "./dist/index.cjs",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,38 @@
+import { toRouteMatcher, createRouter } from ".";
+
+export interface CreateFilterOptions {
+    include?: (string | RegExp)[]
+    exclude?: (string | RegExp)[]
+    strictTrailingSlash?: boolean;
+}
+
+export function createFilter (options: CreateFilterOptions = {}) : (path: string) => boolean {
+  const include = options.include || [];
+  const exclude = options.exclude || [];
+
+  return function (path: string): boolean {
+    for (const v of [{ rules: exclude, result: false }, { rules: include, result: true }]) {
+      const regexRules = v.rules.filter(r => r instanceof RegExp) as RegExp[];
+      if (regexRules.some(r => r.test(path))) {
+        return v.result;
+      }
+      const stringRules = v.rules.filter(r => typeof r === "string") as string[];
+      if (stringRules.length > 0) {
+        const routes = {};
+        for (const r of stringRules) {
+          // quick scan of literal string matches
+          if (r === path) {
+            return v.result;
+          }
+          // need to flip the array data for radix3 format, true value is arbitrary
+          routes[r] = true;
+        }
+        const routeRulesMatcher = toRouteMatcher(createRouter({ routes, ...options }));
+        if (routeRulesMatcher.matchAll(path).length > 0) {
+          return Boolean(v.result);
+        }
+      }
+    }
+    return include.length === 0;
+  };
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,9 @@
 import { toRouteMatcher, createRouter } from ".";
 
 export interface CreateFilterOptions {
-    include?: (string | RegExp)[]
-    exclude?: (string | RegExp)[]
-    strictTrailingSlash?: boolean;
+  include?: (string | RegExp)[]
+  exclude?: (string | RegExp)[]
+  strictTrailingSlash?: boolean;
 }
 
 export function createFilter (options: CreateFilterOptions = {}) : (path: string) => boolean {
@@ -17,20 +17,15 @@ export function createFilter (options: CreateFilterOptions = {}) : (path: string
         return v.result;
       }
       const stringRules = v.rules.filter(r => typeof r === "string") as string[];
-      if (stringRules.length > 0) {
-        const routes = {};
-        for (const r of stringRules) {
-          // quick scan of literal string matches
-          if (r === path) {
-            return v.result;
-          }
-          // need to flip the array data for radix3 format, true value is arbitrary
-          routes[r] = true;
-        }
-        const routeRulesMatcher = toRouteMatcher(createRouter({ routes, ...options }));
-        if (routeRulesMatcher.matchAll(path).length > 0) {
-          return Boolean(v.result);
-        }
+      if (stringRules.length === 0) {
+        continue;
+      }
+      const routes: Record<string, true> = {};
+      // need to flip the array data, true value is arbitrary
+      for (const r of stringRules) { routes[r] = true; }
+      const routeRulesMatcher = toRouteMatcher(createRouter({ routes, ...options }));
+      if (routeRulesMatcher.matchAll(path).length > 0) {
+        return Boolean(v.result);
       }
     }
     return include.length === 0;

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "vitest";
+import { createFilter } from "../src/utils";
+
+describe("createFilter", () => {
+  const excludeFilter = createFilter({
+    exclude: ["/admin/**", "/admin", /^\/regex\/.*/]
+  });
+
+  const valid: string[] = [
+    "/foo",
+    "/foo/",
+    "/foo/bar",
+    "/foo/bar/",
+    "/bar/foo/",
+    "/prefixed/admin/",
+    "/some/path/regex/may/catch"
+  ];
+  const invalid: string[] = [
+    "/admin",
+    "/admin/",
+    "/admin/test",
+    "/admin/foo/some-really-long/url",
+    "/regex/path",
+    "/regex/"
+  ];
+
+  for (const t of valid) {
+    test(`excludeFilter: ${t} valid`, () => {
+      expect(excludeFilter(t)).toBeTruthy();
+    });
+  }
+  for (const t of invalid) {
+    test(`excludeFilter: ${t} invalid`, () => {
+      expect(excludeFilter(t)).toBeFalsy();
+    });
+  }
+
+  const includeFilter = createFilter({
+    include: ["/admin/**", "/admin", /^\/regex\/.*/],
+    exclude: ["/admin/login"]
+  });
+
+  for (const t of [...valid, "/admin/login"]) {
+    test(`includeFilter: ${t} invalid`, () => {
+      expect(includeFilter(t)).toBeFalsy();
+    });
+  }
+  for (const t of invalid) {
+    test(`includeFilter: ${t} valid`, () => {
+      expect(includeFilter(t)).toBeTruthy();
+    });
+  }
+
+  const bothFilter = createFilter({
+    include: ["/admin/**", /^\/regex\/.*/],
+    exclude: ["/admin/foo/**", /^\/regex\/foo\/.*/]
+  });
+
+  for (const t of ["/admin/fo", "/regex/bar"]) {
+    test(`bothFilter: ${t} valid`, () => {
+      expect(bothFilter(t)).toBeTruthy();
+    });
+  }
+  for (const t of ["/admin/foo/", "/regex/foo/test"]) {
+    test(`bothFilter: ${t} invalid`, () => {
+      expect(bothFilter(t)).toBeFalsy();
+    });
+  }
+});
+
+describe("createFilter example", () => {
+  const adminUrl = createFilter({
+    include: ["/admin/**", "/admin", /^\/_api\/\d*/]
+  });
+
+  for (const t of ["/admin", "/admin/", "/admin/foo", "/admin/foo/bar", "/_api/123"]) {
+    test(`adminUrl: ${t} valid`, () => {
+      expect(adminUrl(t)).toBeTruthy();
+    });
+  }
+});


### PR DESCRIPTION
Copied from https://github.com/unjs/ufo/pull/99

----

The [createFilter](https://github.com/rollup/rollup-pluginutils#createfilter) is a popular util from Rollup to filter system paths when transforming modules. This PR introduces a port of that util, but for URL paths.

## Why?

I'm working on a Nuxt module that allows end users to filter paths that it should run on (nuxt-delay-hydration v1). I need something that is straightforward to define inclusions and exclusions.

Generally, this function can be used wherever the end user needs to target a set of routes with certain exclusions.

## How

The API is pretty much the same as the rollup createFilter, supporting whatever tokens Radix3 supports as well as regex. 

I'm open to dropping regex support if you want to keep parity with the rest of the Radix3 API, let me know your thoughts.

Thanks!