### PR TITLE
fix(matchAll): sort routes with same type

### DIFF
--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -32,27 +32,36 @@ function _createRouteTable(): RouteTable {
 }
 
 function _matchRoutes(path: string, table: RouteTable): RadixNodeData[] {
+  // Order should be from less specific to most specific
   const matches = [];
+
   // Wildcard
-  for (const [key, value] of table.wildcard) {
+  for (const [key, value] of _sortRoutesMap(table.wildcard)) {
     if (path.startsWith(key)) {
       matches.push(value);
     }
   }
+
   // Dynamic
-  for (const [key, value] of table.dynamic) {
+  for (const [key, value] of _sortRoutesMap(table.dynamic)) {
     if (path.startsWith(key + "/")) {
       const subPath =
         "/" + path.slice(key.length).split("/").splice(2).join("/");
       matches.push(..._matchRoutes(subPath, value));
     }
   }
+
   // Static
   const staticMatch = table.static.get(path);
   if (staticMatch) {
     matches.push(staticMatch);
   }
+
   return matches.filter(Boolean);
+}
+
+function _sortRoutesMap(m: Map<string, any>) {
+  return [...m.entries()].sort((a, b) => a[0].length - b[0].length);
 }
 
 function _routerNodeToTable(

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -10,10 +10,11 @@ describe("Route matcher", function () {
     const router = createRouter({
       routes: {
         "/foo": { m: "foo" },
-        "/foo/**": { m: "foo/**" },
+        "/foo/**": { m: "foo/**", order: "2" },
         "/foo/bar": { m: "foo/bar" },
-        "/foo/bar/baz": { m: "foo/bar/baz" },
-        "/foo/*/baz": { m: "foo/*/baz" },
+        "/foo/bar/baz": { m: "foo/bar/baz", order: "4" },
+        "/foo/*/baz": { m: "foo/*/baz", order: "3" },
+        "/**": { order: "1" },
       },
     });
 
@@ -23,13 +24,19 @@ describe("Route matcher", function () {
     expect(matches).to.toMatchInlineSnapshot(`
       [
         {
+          "order": "1",
+        },
+        {
           "m": "foo/**",
+          "order": "2",
         },
         {
           "m": "foo/*/baz",
+          "order": "3",
         },
         {
           "m": "foo/bar/baz",
+          "order": "4",
         },
       ]
     `);


### PR DESCRIPTION
resolves #44

The return value of `matchAll` normally should return from less specific to most specific matches (wildcard > params > static). However when checking same kind of rules, like between wildcards, we was not sorting them. Comparing by length as simplest possible workaround we might improve it later if there was more edge cases when comparing same type.