### PR TITLE
feat!: add http method matching

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -9,9 +9,9 @@ Below results are based on my personal PC using WSL2. You can use provided scrip
 Directly benchmarking `lookup` performance using [benchmark](https://www.npmjs.com/package/benchmark)
 
 Scripts:
+
 - `pnpm bench`
 - `pnpm bench:profile` (using [0x](https://www.npmjs.com/package/0x) to generate flamegraph)
-
 
 ```
 --- Test environment ---
@@ -34,14 +34,14 @@ Stats:
 lookup x 1,365,609 ops/sec ±0.64% (88 runs sampled)
 Stats:
  - /choot/123: 7074324
- ```
+```
 
 ## HTTP Benchmark
-
 
 Using [`autocannon`](https://github.com/mcollina/autocannon) and a simple http listener using lookup for realworld performance.
 
 Scripts:
+
 - `pnpm bench:http`
 
 ```

--- a/benchmark/direct.mjs
+++ b/benchmark/direct.mjs
@@ -1,8 +1,14 @@
 /* eslint-disable no-console */
 import Benchmark from "benchmark"; // https://www.npmjs.com/package/benchmark'
-import { printEnv, benchSets, printStats, router, logSection } from "./utils.mjs";
+import {
+  printEnv,
+  benchSets,
+  printStats,
+  router,
+  logSection,
+} from "./utils.mjs";
 
-async function main () {
+async function main() {
   printEnv();
 
   for (const bench of benchSets) {
@@ -11,13 +17,19 @@ async function main () {
     const stats = {};
     suite.add("lookup", () => {
       for (const req of bench.requests) {
-        const match = router.lookup(req.path);
-        if (!match) { stats[match] = (stats[match] || 0) + 1; }
+        const match = router.lookup(req.path, { method: req.method });
+        if (!match) {
+          stats[match] = (stats[match] || 0) + 1;
+        }
         stats[req.path] = (stats[req.path] || 0) + 1;
       }
     });
-    suite.on("cycle", (event) => { console.log(String(event.target)); });
-    const promise = new Promise(resolve => suite.on("complete", () => resolve()));
+    suite.on("cycle", (event) => {
+      console.log(String(event.target));
+    });
+    const promise = new Promise((resolve) =>
+      suite.on("complete", () => resolve())
+    );
     suite.run({ async: true });
     await promise;
     printStats(stats);

--- a/benchmark/utils.mjs
+++ b/benchmark/utils.mjs
@@ -3,11 +3,15 @@ import { readFileSync } from "node:fs";
 import os from "node:os";
 import { createRouter } from "radix3";
 
-export const logSection = (title) => { console.log(`\n--- ${title} ---\n`); };
+export const logSection = (title) => {
+  console.log(`\n--- ${title} ---\n`);
+};
 
-const pkgVersion = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")).version;
+const pkgVersion = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8")
+).version;
 
-export function printEnv () {
+export function printEnv() {
   logSection("Test environment");
   console.log("Node.js version:", process.versions.node);
   console.log("Radix3 version:", pkgVersion);
@@ -17,36 +21,45 @@ export function printEnv () {
   console.log("");
 }
 
-export function printStats (stats) {
-  console.log("Stats:\n" + Object.entries(stats).map(([path, hits]) => ` - ${path}: ${hits}`).join("\n"));
+export function printStats(stats) {
+  console.log(
+    "Stats:\n" +
+      Object.entries(stats)
+        .map(([path, hits]) => ` - ${path}: ${hits}`)
+        .join("\n")
+  );
 }
 
 export const router = createRouter({
-  routes: Object.fromEntries([
-    "/hello",
-    "/cool",
-    "/hi",
-    "/helium",
-    "/coooool",
-    "/chrome",
-    "/choot",
-    "/choot/:choo",
-    "/ui/**",
-    "/ui/components/**"
-  ].map(path => [path, { path }]))
+  routes: Object.fromEntries(
+    [
+      "/hello",
+      "/cool",
+      "/hi",
+      "/helium",
+      "/coooool",
+      "/chrome",
+      "/choot",
+      "/choot/:choo",
+      "/ui/**",
+      "/ui/components/**",
+    ].map((path) => [path, { path }])
+  ),
 });
+
+router.insert("/method-get", { path: "/method-get" }, { method: "GET" });
 
 export const benchSets = [
   {
     title: "static route",
-    requests: [
-      { path: "/choot" }
-    ]
+    requests: [{ path: "/choot" }],
   },
   {
     title: "dynamic route",
-    requests: [
-      { path: "/choot/123" }
-    ]
-  }
+    requests: [{ path: "/choot/123" }],
+  },
+  {
+    title: "method route",
+    requests: [{ path: "/method-get", method: "GET" }],
+  },
 ];

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "bench:profile": "0x -o -D benchmark/.profile -- node ./benchmark/direct.mjs",
     "build": "unbuild",
     "dev": "vitest",
-    "lint": "eslint --ext .ts,.mjs . && prettier -c src tests",
-    "lint:fix": "eslint --fix --ext .ts,.mjs . && prettier -w src tests",
+    "lint": "eslint --ext .ts,.mjs . && prettier -c src tests benchmark",
+    "lint:fix": "eslint --fix --ext .ts,.mjs . && prettier -w src tests benchmark",
     "playground": "pnpm jiti ./playground.ts",
     "release": "pnpm test && pnpm build && changelogen --release && git push --follow-tags && pnpm publish",
     "test": "pnpm lint && vitest run"

--- a/src/router.ts
+++ b/src/router.ts
@@ -5,7 +5,7 @@ import type {
   RadixRouter,
   RadixNodeData,
   RadixRouterOptions,
-  HTTPMethod,
+  LookupOptions,
 } from "./types";
 import { HTTPMethods, NODE_TYPES } from "./types";
 
@@ -25,7 +25,7 @@ export function createRouter<T extends RadixNodeData = RadixNodeData>(
     for (const path in options.routes) {
       Array.isArray(options.routes[path]) &&
       options.routes[path].length === 2 &&
-      HTTPMethods.includes(options.routes[path][0])
+      HTTPMethods.includes(options.routes[path][0].method)
         ? insert(
             ctx,
             normalizeTrailingSlash(path),
@@ -39,10 +39,10 @@ export function createRouter<T extends RadixNodeData = RadixNodeData>(
   return {
     ctx,
     // @ts-expect-error - types are not matching
-    lookup: (path: string, options?: { method?: HTTPMethod }) =>
-      lookup(ctx, normalizeTrailingSlash(path), options?.method),
-    insert: (path: string, data: any, options?: { method?: HTTPMethod }) =>
-      insert(ctx, normalizeTrailingSlash(path), data, options?.method),
+    lookup: (path: string, options?: LookupOptions) =>
+      lookup(ctx, normalizeTrailingSlash(path), options),
+    insert: (path: string, data: any, options?: LookupOptions) =>
+      insert(ctx, normalizeTrailingSlash(path), data, options),
     remove: (path: string) => remove(ctx, normalizeTrailingSlash(path)),
   };
 }
@@ -50,8 +50,10 @@ export function createRouter<T extends RadixNodeData = RadixNodeData>(
 function lookup(
   ctx: RadixRouterContext,
   path: string,
-  method?: HTTPMethod
+  options?: LookupOptions
 ): MatchedRoute {
+  const method = options?.method;
+
   const staticPathNode = ctx.staticRoutesMap[`${method ?? "ALL"} ${path}`];
   if (staticPathNode) {
     return staticPathNode.data;
@@ -116,8 +118,10 @@ function insert(
   ctx: RadixRouterContext,
   path: string,
   data: unknown,
-  method?: HTTPMethod
+  options?: LookupOptions
 ) {
+  const method = options?.method;
+
   let isStaticRoute = true;
 
   const sections = path.split("/");

--- a/src/router.ts
+++ b/src/router.ts
@@ -6,6 +6,7 @@ import type {
   RadixNodeData,
   RadixRouterOptions,
   LookupOptions,
+  RadixRouterOptionsPayload,
 } from "./types";
 import { HTTPMethods, NODE_TYPES } from "./types";
 
@@ -21,18 +22,22 @@ export function createRouter<T extends RadixNodeData = RadixNodeData>(
   const normalizeTrailingSlash = (p: string) =>
     options.strictTrailingSlash ? p : p.replace(/\/$/, "") || "/";
 
+  const isRadixRouterOptionsPayload = (
+    payload: RadixRouterOptions["routes"][string]
+  ): payload is RadixRouterOptionsPayload =>
+    typeof payload === "object" && "method" in payload && "payload" in payload;
+
   if (options.routes) {
     for (const path in options.routes) {
-      Array.isArray(options.routes[path]) &&
-      options.routes[path].length === 2 &&
-      HTTPMethods.includes(options.routes[path][0].method)
+      const routeOptions = options.routes[path];
+      isRadixRouterOptionsPayload(routeOptions)
         ? insert(
             ctx,
             normalizeTrailingSlash(path),
-            options.routes[path][1],
-            options.routes[path][0]
+            routeOptions.payload,
+            routeOptions
           )
-        : insert(ctx, normalizeTrailingSlash(path), options.routes[path]);
+        : insert(ctx, normalizeTrailingSlash(path), routeOptions);
     }
   }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -39,10 +39,10 @@ export function createRouter<T extends RadixNodeData = RadixNodeData>(
   return {
     ctx,
     // @ts-expect-error - types are not matching
-    lookup: (path: string, method?: HTTPMethod) =>
-      lookup(ctx, normalizeTrailingSlash(path), method),
-    insert: (path: string, data: any, method?: HTTPMethod) =>
-      insert(ctx, normalizeTrailingSlash(path), data, method),
+    lookup: (path: string, options?: { method?: HTTPMethod }) =>
+      lookup(ctx, normalizeTrailingSlash(path), options?.method),
+    insert: (path: string, data: any, options?: { method?: HTTPMethod }) =>
+      insert(ctx, normalizeTrailingSlash(path), data, options?.method),
     remove: (path: string) => remove(ctx, normalizeTrailingSlash(path)),
   };
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -8,7 +8,7 @@ import type {
   LookupOptions,
   RadixRouterOptionsPayload,
 } from "./types";
-import { HTTPMethods, NODE_TYPES } from "./types";
+import { NODE_TYPES } from "./types";
 
 export function createRouter<T extends RadixNodeData = RadixNodeData>(
   options: RadixRouterOptions = {}

--- a/src/router.ts
+++ b/src/router.ts
@@ -98,7 +98,7 @@ function lookup(
     return null;
   }
 
-  if (node.method && node.method !== method) {
+  if (method && node.method !== method) {
     return null;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,18 +59,23 @@ export interface RadixRouter<T extends RadixNodeData = RadixNodeData> {
   /**
    * Perform lookup of given path in radix tree
    * @param path - the path to search for
+   * @param method - the HTTP method to search for
    *
    * @returns The data that was originally inserted into the tree
    */
-  lookup(path: string, method?: HTTPMethod): MatchedRoute<T> | null;
+  lookup(
+    path: string,
+    options?: { method?: HTTPMethod }
+  ): MatchedRoute<T> | null;
 
   /**
    * Perform an insert into the radix tree
    * @param path - the prefix to match
    * @param data - the associated data to path
+   * @param method - the HTTP method to search for
    *
    */
-  insert(path: string, data: T, method?: HTTPMethod): void;
+  insert(path: string, data: T, options?: { method?: HTTPMethod }): void;
 
   /**
    * Perform a remove on the tree

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,11 +43,19 @@ export interface RadixNode<T extends RadixNodeData = RadixNodeData> {
 }
 
 export type RadixRouterOptionsPayload = Omit<InsertOptions, "path">;
-export interface RadixRouterOptions {
+
+interface RadixRouterOptionsV1 {
   strictTrailingSlash?: boolean;
-  method?: boolean;
-  routes?: Record<string, unknown> | Record<string, RadixRouterOptionsPayload>;
+  routes?: Record<string, unknown>;
 }
+
+interface RadixRouterOptionsV2 {
+  strictTrailingSlash?: boolean;
+  method: boolean;
+  routes: Record<string, RadixRouterOptionsPayload>;
+}
+
+export type RadixRouterOptions = RadixRouterOptionsV1 | RadixRouterOptionsV2;
 
 export type StaticRoutesMap = Record<HTTPMethod, Record<string, RadixNode>>;
 export interface RadixRouterContext<T extends RadixNodeData = RadixNodeData> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export const HTTPMethods = [
+const HTTPMethods = [
   "GET",
   "HEAD",
   "PATCH",

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,12 @@ export interface RadixRouterContext<T extends RadixNodeData = RadixNodeData> {
 }
 
 export type LookupOptions = { method?: HTTPMethod };
+export type InsertOptions<T> = {
+  path: string;
+  payload: T;
+  method?: HTTPMethod;
+};
+
 export interface RadixRouter<T extends RadixNodeData = RadixNodeData> {
   ctx: RadixRouterContext<T>;
 
@@ -76,10 +82,15 @@ export interface RadixRouter<T extends RadixNodeData = RadixNodeData> {
    * Perform an insert into the radix tree
    * @param path - the prefix to match
    * @param data - the associated data to path
-   * @param method - insert options such as method
    *
    */
-  insert(path: string, data: T, options?: LookupOptions): void;
+  insert(path: string, data: T): void;
+  /**
+   * Perform an insert into the radix tree
+   * @param options - the options to insert
+   *
+   */
+  insert(options: InsertOptions<T>): void;
 
   /**
    * Perform a remove on the tree

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ export interface RadixRouterContext<T extends RadixNodeData = RadixNodeData> {
   staticRoutesMap: Record<string, RadixNode>;
 }
 
+export type LookupOptions = { method?: HTTPMethod };
 export interface RadixRouter<T extends RadixNodeData = RadixNodeData> {
   ctx: RadixRouterContext<T>;
 
@@ -63,10 +64,7 @@ export interface RadixRouter<T extends RadixNodeData = RadixNodeData> {
    *
    * @returns The data that was originally inserted into the tree
    */
-  lookup(
-    path: string,
-    options?: { method?: HTTPMethod }
-  ): MatchedRoute<T> | null;
+  lookup(path: string, options?: LookupOptions): MatchedRoute<T> | null;
 
   /**
    * Perform an insert into the radix tree
@@ -75,7 +73,7 @@ export interface RadixRouter<T extends RadixNodeData = RadixNodeData> {
    * @param method - insert options such as method
    *
    */
-  insert(path: string, data: T, options?: { method?: HTTPMethod }): void;
+  insert(path: string, data: T, options?: LookupOptions): void;
 
   /**
    * Perform a remove on the tree

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,9 +42,15 @@ export interface RadixNode<T extends RadixNodeData = RadixNodeData> {
   placeholderChildNode: RadixNode<T> | null;
 }
 
+export type RadixRouterOptionsPayload = {
+  method: HTTPMethod;
+  payload: unknown;
+};
+
 export interface RadixRouterOptions {
   strictTrailingSlash?: boolean;
-  routes?: Record<string, any>;
+  method?: boolean;
+  routes?: Record<string, unknown> | Record<string, RadixRouterOptionsPayload>;
 }
 
 export interface RadixRouterContext<T extends RadixNodeData = RadixNodeData> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-const HTTPMethods = [
+export const HTTPMethods = [
   "GET",
   "HEAD",
   "PATCH",
@@ -49,10 +49,11 @@ export interface RadixRouterOptions {
   routes?: Record<string, unknown> | Record<string, RadixRouterOptionsPayload>;
 }
 
+export type StaticRoutesMap = Record<HTTPMethod, Record<string, RadixNode>>;
 export interface RadixRouterContext<T extends RadixNodeData = RadixNodeData> {
   options: RadixRouterOptions;
   rootNode: RadixNode<T>;
-  staticRoutesMap: Record<string, RadixNode>;
+  staticRoutesMap: StaticRoutesMap;
 }
 
 export type LookupOptions = { method?: HTTPMethod };

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export const NODE_TYPES = {
 type _NODE_TYPES = typeof NODE_TYPES;
 export type NODE_TYPE = _NODE_TYPES[keyof _NODE_TYPES];
 
-export type _RadixNodeDataObject = { params?: never; [key: string]: any };
+type _RadixNodeDataObject = { params?: never; [key: string]: any };
 export type RadixNodeData<
   T extends _RadixNodeDataObject = _RadixNodeDataObject
 > = T;

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,7 +59,7 @@ export interface RadixRouter<T extends RadixNodeData = RadixNodeData> {
   /**
    * Perform lookup of given path in radix tree
    * @param path - the path to search for
-   * @param method - the HTTP method to search for
+   * @param options - lookup options such as method
    *
    * @returns The data that was originally inserted into the tree
    */
@@ -72,7 +72,7 @@ export interface RadixRouter<T extends RadixNodeData = RadixNodeData> {
    * Perform an insert into the radix tree
    * @param path - the prefix to match
    * @param data - the associated data to path
-   * @param method - the HTTP method to search for
+   * @param method - insert options such as method
    *
    */
   insert(path: string, data: T, options?: { method?: HTTPMethod }): void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,18 @@
+export const HTTPMethods = [
+  "GET",
+  "HEAD",
+  "PATCH",
+  "POST",
+  "PUT",
+  "DELETE",
+  "CONNECT",
+  "OPTIONS",
+  "TRACE",
+  "ALL",
+] as const;
+
+export type HTTPMethod = (typeof HTTPMethods)[number];
+
 export const NODE_TYPES = {
   NORMAL: 0 as const,
   WILDCARD: 1 as const,
@@ -7,7 +22,7 @@ export const NODE_TYPES = {
 type _NODE_TYPES = typeof NODE_TYPES;
 export type NODE_TYPE = _NODE_TYPES[keyof _NODE_TYPES];
 
-type _RadixNodeDataObject = { params?: never; [key: string]: any };
+export type _RadixNodeDataObject = { params?: never; [key: string]: any };
 export type RadixNodeData<
   T extends _RadixNodeDataObject = _RadixNodeDataObject
 > = T;
@@ -21,6 +36,7 @@ export interface RadixNode<T extends RadixNodeData = RadixNodeData> {
   parent: RadixNode<T> | null;
   children: Map<string, RadixNode<T>>;
   data: RadixNodeData | null;
+  method: HTTPMethod | null;
   paramName: string | null;
   wildcardChildNode: RadixNode<T> | null;
   placeholderChildNode: RadixNode<T> | null;
@@ -46,7 +62,7 @@ export interface RadixRouter<T extends RadixNodeData = RadixNodeData> {
    *
    * @returns The data that was originally inserted into the tree
    */
-  lookup(path: string): MatchedRoute<T> | null;
+  lookup(path: string, method?: HTTPMethod): MatchedRoute<T> | null;
 
   /**
    * Perform an insert into the radix tree
@@ -54,7 +70,7 @@ export interface RadixRouter<T extends RadixNodeData = RadixNodeData> {
    * @param data - the associated data to path
    *
    */
-  insert(path: string, data: T): void;
+  insert(path: string, data: T, method?: HTTPMethod): void;
 
   /**
    * Perform a remove on the tree

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,11 +42,7 @@ export interface RadixNode<T extends RadixNodeData = RadixNodeData> {
   placeholderChildNode: RadixNode<T> | null;
 }
 
-export type RadixRouterOptionsPayload = {
-  method: HTTPMethod;
-  payload: unknown;
-};
-
+export type RadixRouterOptionsPayload = Omit<InsertOptions, "path">;
 export interface RadixRouterOptions {
   strictTrailingSlash?: boolean;
   method?: boolean;
@@ -60,7 +56,7 @@ export interface RadixRouterContext<T extends RadixNodeData = RadixNodeData> {
 }
 
 export type LookupOptions = { method?: HTTPMethod };
-export type InsertOptions<T> = {
+export type InsertOptions<T = unknown> = {
   path: string;
   payload: T;
   method?: HTTPMethod;

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import { createRouter, HTTPMethod, NODE_TYPES } from "../src";
 
 type RouteDefinition = string | { path: string; method: HTTPMethod };
-
 export function createRoutes(paths: RouteDefinition[]) {
   return Object.fromEntries(
     paths.map((path) => {
@@ -150,6 +149,15 @@ describe("Router insert", function () {
 
     expect(router.ctx.staticRoutesMap.ALL[route]).to.exist;
   });
+
+  it("should insert static routes with methods into the static route map", function () {
+    const router = createRouter();
+    const route = "/api/v2/route";
+    router.insert({ path: route, method: "PUT", payload: {} });
+
+    expect(router.ctx.staticRoutesMap.PUT[route]).to.exist;
+  });
+
   it("should not insert variable routes into the static route map", function () {
     const router = createRouter();
     const routeA = "/api/v2/**";

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -330,7 +330,7 @@ describe("Router remove", function () {
       expect(router.lookup("hello")).to.deep.equal({ path: "hello" });
     });
     it("can insert routes with method ", function () {
-      router.insert("cool", { path: "cool" }, { method: "GET" });
+      router.insert({ path: "cool", method: "GET", payload: { path: "cool" } });
       expect(router.lookup("cool", { method: "POST" })).to.deep.equal(null);
       expect(router.lookup("cool", { method: "GET" })).to.deep.equal({
         path: "cool",

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -329,13 +329,13 @@ describe("Router remove", function () {
       // console.log("CONTEXT");
       // console.dir(router.ctx, { depth: 4 });
 
-      expect(router.lookup("hello")).to.deep.equal(null);
       expect(router.lookup("hello", "GET")).to.deep.equal(null);
       expect(router.lookup("hello", "POST")).to.deep.equal({ path: "hello" });
+      expect(router.lookup("hello")).to.deep.equal({ path: "hello" });
 
-      expect(router.lookup("cool")).to.deep.equal(null);
       expect(router.lookup("cool", "POST")).to.deep.equal(null);
       expect(router.lookup("cool", "GET")).to.deep.equal({ path: "cool" });
+      expect(router.lookup("cool")).to.deep.equal({ path: "cool" });
 
       expect(router.lookup("ui/components/snackbars", "POST")).to.deep.equal(
         null

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -324,18 +324,24 @@ describe("Router remove", function () {
       // console.log("CONTEXT");
       // console.dir(router.ctx, { depth: 4 });
 
-      expect(router.lookup("hello", "GET")).to.deep.equal(null);
-      expect(router.lookup("hello", "POST")).to.deep.equal({ path: "hello" });
+      expect(router.lookup("hello", { method: "GET" })).to.deep.equal(null);
+      expect(router.lookup("hello", { method: "POST" })).to.deep.equal({
+        path: "hello",
+      });
       expect(router.lookup("hello")).to.deep.equal({ path: "hello" });
 
-      expect(router.lookup("cool", "POST")).to.deep.equal(null);
-      expect(router.lookup("cool", "GET")).to.deep.equal({ path: "cool" });
+      expect(router.lookup("cool", { method: "POST" })).to.deep.equal(null);
+      expect(router.lookup("cool", { method: "GET" })).to.deep.equal({
+        path: "cool",
+      });
       expect(router.lookup("cool")).to.deep.equal({ path: "cool" });
 
-      expect(router.lookup("ui/components/snackbars", "GET")).to.deep.equal(
-        null
-      );
-      expect(router.lookup("ui/components/snackbars", "POST")).to.deep.equal({
+      expect(
+        router.lookup("ui/components/snackbars", { method: "GET" })
+      ).to.deep.equal(null);
+      expect(
+        router.lookup("ui/components/snackbars", { method: "POST" })
+      ).to.deep.equal({
         path: "ui/components/**",
         params: { _: "snackbars" },
       });

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -7,7 +7,10 @@ export function createRoutes(paths: string[]) {
 
 function createRoutesWithMethod(routes: string[]) {
   return Object.fromEntries(
-    routes.map((path, i) => [path, [i & 1 ? "GET" : "POST", { path }]])
+    routes.map((path, i) => [
+      path,
+      [{ method: i & 1 ? "GET" : "POST" }, { path }],
+    ])
   );
 }
 
@@ -310,20 +313,19 @@ describe("Router remove", function () {
   });
 
   describe("Router with method", function () {
-    it("should be able to match with methods", function () {
-      const router = createRouter({
-        routes: createRoutesWithMethod([
-          "hello",
-          "cool",
-          "choot/:choo",
-          "ui/**",
-          "ui/components/**",
-        ]),
-      });
-
-      // console.log("CONTEXT");
-      // console.dir(router.ctx, { depth: 4 });
-
+    const router = createRouter({
+      routes: createRoutesWithMethod([
+        "hello",
+        "cool",
+        "choot/:choo",
+        "ui/**",
+        "ui/components/**",
+        "**",
+      ]),
+    });
+    // console.log("CONTEXT");
+    // console.dir(router.ctx, { depth: 4 });
+    it("can match simple route with method ", function () {
       expect(router.lookup("hello", { method: "GET" })).to.deep.equal(null);
       expect(router.lookup("hello", { method: "POST" })).to.deep.equal({
         path: "hello",
@@ -335,13 +337,24 @@ describe("Router remove", function () {
         path: "cool",
       });
       expect(router.lookup("cool")).to.deep.equal({ path: "cool" });
+    });
 
-      expect(
-        router.lookup("ui/components/snackbars", { method: "GET" })
-      ).to.deep.equal(null);
-      expect(
-        router.lookup("ui/components/snackbars", { method: "POST" })
-      ).to.deep.equal({
+    it("can match wildcard route with method ", function () {
+      expect(router.lookup("**", { method: "DELETE" })).to.deep.equal(null);
+      expect(router.lookup("**", { method: "GET" })).to.deep.equal({
+        path: "**",
+      });
+      expect(router.lookup("**")).to.deep.equal({ path: "**" });
+    });
+
+    it("can match route with parameters and method ", function () {
+      const snacbkars = "ui/components/snackbars";
+      expect(router.lookup(snacbkars, { method: "GET" })).to.deep.equal(null);
+      expect(router.lookup(snacbkars, { method: "POST" })).to.deep.equal({
+        path: "ui/components/**",
+        params: { _: "snackbars" },
+      });
+      expect(router.lookup(snacbkars)).to.deep.equal({
         path: "ui/components/**",
         params: { _: "snackbars" },
       });

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -148,7 +148,7 @@ describe("Router insert", function () {
     const route = "/api/v2/route";
     router.insert(route, {});
 
-    expect(router.ctx.staticRoutesMap[`ALL ${route}`]).to.exist;
+    expect(router.ctx.staticRoutesMap.ALL[route]).to.exist;
   });
   it("should not insert variable routes into the static route map", function () {
     const router = createRouter();
@@ -157,8 +157,8 @@ describe("Router insert", function () {
     router.insert(routeA, {});
     router.insert(routeB, {});
 
-    expect(router.ctx.staticRoutesMap[`ALL ${routeA}`]).to.not.exist;
-    expect(router.ctx.staticRoutesMap[`ALL ${routeB}`]).to.not.exist;
+    expect(router.ctx.staticRoutesMap.ALL[routeA]).to.not.exist;
+    expect(router.ctx.staticRoutesMap.ALL[routeB]).to.not.exist;
   });
 
   it("should insert placeholder and wildcard nodes correctly into the tree", function () {

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -328,16 +328,16 @@ describe("Router remove", function () {
         { path: "**", method: "PUT" },
       ]),
     });
-    // console.log("CONTEXT");
-    // console.dir(router.ctx, { depth: 4 });
-    it("can match simple route with method ", function () {
+
+    it("can match a route with a method ", function () {
       expect(router.lookup("hello", { method: "POST" })).to.deep.equal(null);
       expect(router.lookup("hello", { method: "GET" })).to.deep.equal({
         path: "hello",
       });
       expect(router.lookup("hello")).to.deep.equal({ path: "hello" });
     });
-    it("can insert routes with method ", function () {
+
+    it("can insert routes with a method ", function () {
       router.insert({ path: "cool", method: "GET", payload: { path: "cool" } });
       expect(router.lookup("cool", { method: "POST" })).to.deep.equal(null);
       expect(router.lookup("cool", { method: "GET" })).to.deep.equal({
@@ -346,7 +346,7 @@ describe("Router remove", function () {
       expect(router.lookup("cool")).to.deep.equal({ path: "cool" });
     });
 
-    it("can match route with parameters and method ", function () {
+    it("can match a route with parameters and a method ", function () {
       const snacbkars = "ui/components/snackbars";
       expect(router.lookup(snacbkars, { method: "GET" })).to.deep.equal(null);
       expect(router.lookup(snacbkars, { method: "POST" })).to.deep.equal({
@@ -359,7 +359,7 @@ describe("Router remove", function () {
       });
     });
 
-    it("can match wildcard route with method ", function () {
+    it("can match a wildcard route with a method ", function () {
       expect(router.lookup("**", { method: "DELETE" })).to.deep.equal(null);
       expect(router.lookup("**", { method: "PUT" })).to.deep.equal({
         path: "**",

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -315,11 +315,6 @@ describe("Router remove", function () {
         routes: createRoutesWithMethod([
           "hello",
           "cool",
-          "hi",
-          "helium",
-          "coooool",
-          "chrome",
-          "choot",
           "choot/:choo",
           "ui/**",
           "ui/components/**",
@@ -337,10 +332,10 @@ describe("Router remove", function () {
       expect(router.lookup("cool", "GET")).to.deep.equal({ path: "cool" });
       expect(router.lookup("cool")).to.deep.equal({ path: "cool" });
 
-      expect(router.lookup("ui/components/snackbars", "POST")).to.deep.equal(
+      expect(router.lookup("ui/components/snackbars", "GET")).to.deep.equal(
         null
       );
-      expect(router.lookup("ui/components/snackbars", "GET")).to.deep.equal({
+      expect(router.lookup("ui/components/snackbars", "POST")).to.deep.equal({
         path: "ui/components/**",
         params: { _: "snackbars" },
       });

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { createRouter, HTTPMethod, NODE_TYPES } from "../src";
+import {
+  createRouter,
+  NODE_TYPES,
+  type HTTPMethod,
+  type RadixRouterOptions,
+} from "../src";
 
 type RouteDefinition = string | { path: string; method: HTTPMethod };
 export function createRoutes(paths: RouteDefinition[]) {
@@ -9,7 +14,7 @@ export function createRoutes(paths: RouteDefinition[]) {
         ? [path, { path }]
         : [path.path, { method: path.method, payload: { path: path.path } }];
     })
-  );
+  ) as Required<Pick<RadixRouterOptions, "routes">>["routes"];
 }
 
 function testRouter(paths: string[], tests?: any) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Resolves #58 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds a new syntax to allow http method to be matched with radix3.

```ts
    const router = createRouter();
    router.insert({ path: "v2", method: "GET", payload: { path: "v2" } }); //v2 syntax
    router.insert("v1", { path: "v1", field: 1, anotherField: 2 }); //v1 syntax
```

The current implementation contains a (small) breaking to `staticRoutesMap`, which is now a 2 dimensional array to support fast method matching. A one dimensional approach is possible, but not as robust as the 2 dimensional one https://github.com/unjs/radix3/pull/59#discussion_r1278317571.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
