### PR TITLE
feat: allow exporting/importing matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,23 @@ const matches = matcher.matchAll('/foo/bar/baz')
 // ]
 ```
 
+### Route Matcher Export
+
+It is also possible to export and then rehydrate a matcher from pre-compiled rules.
+
+```ts
+import { exportMatcher, createMatcherFromExport } from 'radix3'
+
+// Assuming you already have a matcher
+// you can export this to a JSON-type object
+const json = exportMatcher(matcher)
+
+// and then rehydrate this later
+const newMatcher = createMatcherFromExport(json)
+
+const matches = matcher.matchAll('/foo/bar/baz')
+```
+
 ## Performance
 
 See [benchmark](./benchmark).

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ const json = exportMatcher(matcher)
 // and then rehydrate this later
 const newMatcher = createMatcherFromExport(json)
 
-const matches = matcher.matchAll('/foo/bar/baz')
+const matches = newMatcher.matchAll('/foo/bar/baz')
 ```
 
 ## Performance

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -37,22 +37,26 @@ function _createRouteTable(): RouteTable {
   };
 }
 
-export function exportMatcher({ ctx }: { ctx: { table: RouteTable }}): MatcherExport {
+function _exportMatcherFromTable(table: RouteTable): MatcherExport {
   const obj = Object.create(null);
 
-  for (const property in ctx.table) {
+  for (const property in table) {
     obj[property] =
       property === "dynamic"
         ? Object.fromEntries(
-            [...ctx.table[property].entries()].map(([key, value]) => [
+            [...table[property].entries()].map(([key, value]) => [
               key,
-              exportMatcher({ ctx: { table: value } }),
+              _exportMatcherFromTable(value),
             ])
           )
-        : Object.fromEntries(ctx.table[property].entries());
+        : Object.fromEntries(table[property].entries());
   }
 
   return obj;
+}
+
+export function exportMatcher(matcher: RouteMatcher): MatcherExport {
+  return _exportMatcherFromTable(matcher.ctx.table);
 }
 
 function _createTableFromExport(matcherExport: MatcherExport): RouteTable {

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -1,4 +1,10 @@
-import { RadixNode, RadixRouter, RadixNodeData, NODE_TYPES, DehydratedRouteTable } from "./types";
+import {
+  RadixNode,
+  RadixRouter,
+  RadixNodeData,
+  NODE_TYPES,
+  DehydratedRouteTable,
+} from "./types";
 
 export interface RouteTable {
   static: Map<string, RadixNodeData>;
@@ -31,30 +37,46 @@ function _createRouteTable(): RouteTable {
   };
 }
 
-export function exportMatcherTable(table: RouteTable): Record<'static' | 'wildcard' | 'dynamic', any> {
-  const obj = Object.create(null)
+export function exportMatcherTable(
+  table: RouteTable
+): Record<"static" | "wildcard" | "dynamic", any> {
+  const obj = Object.create(null);
 
   for (const property in table) {
-    obj[property] = property === 'dynamic'
-      ? Object.fromEntries([...table[property].entries()].map(([key, value]) => [key, exportMatcherTable(value)]))
-      : Object.fromEntries(table[property].entries())
+    obj[property] =
+      property === "dynamic"
+        ? Object.fromEntries(
+            [...table[property].entries()].map(([key, value]) => [
+              key,
+              exportMatcherTable(value),
+            ])
+          )
+        : Object.fromEntries(table[property].entries());
   }
 
-  return obj
+  return obj;
 }
 
-function createTableFromExport (tableImport: DehydratedRouteTable): RouteTable {
-  const table: Partial<RouteTable> = {}
+function createTableFromExport(tableImport: DehydratedRouteTable): RouteTable {
+  const table: Partial<RouteTable> = {};
   for (const property in tableImport) {
-    table[property] = property === 'dynamic'
-      ? new Map(Object.entries(tableImport[property]).map(([key, value]) => [key, createTableFromExport(value as any)]))
-      : new Map(Object.entries(tableImport[property]))
+    table[property] =
+      property === "dynamic"
+        ? new Map(
+            Object.entries(tableImport[property]).map(([key, value]) => [
+              key,
+              createTableFromExport(value as any),
+            ])
+          )
+        : new Map(Object.entries(tableImport[property]));
   }
-  return table as RouteTable
+  return table as RouteTable;
 }
 
-export function createMatcherFromTable(tableImport: DehydratedRouteTable): RouteMatcher {
-  return _createMatcher(createTableFromExport(tableImport))
+export function createMatcherFromTable(
+  tableImport: DehydratedRouteTable
+): RouteMatcher {
+  return _createMatcher(createTableFromExport(tableImport));
 }
 
 function _matchRoutes(path: string, table: RouteTable): RadixNodeData[] {

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -55,7 +55,7 @@ export function exportMatcherTable(table: RouteTable): DehydratedRouteTable {
   return obj;
 }
 
-function createTableFromExport(tableImport: DehydratedRouteTable): RouteTable {
+function _createTableFromExport(tableImport: DehydratedRouteTable): RouteTable {
   const table: Partial<RouteTable> = {};
   for (const property in tableImport) {
     table[property] =
@@ -63,7 +63,7 @@ function createTableFromExport(tableImport: DehydratedRouteTable): RouteTable {
         ? new Map(
             Object.entries(tableImport[property]).map(([key, value]) => [
               key,
-              createTableFromExport(value as any),
+              _createTableFromExport(value as any),
             ])
           )
         : new Map(Object.entries(tableImport[property]));
@@ -74,7 +74,7 @@ function createTableFromExport(tableImport: DehydratedRouteTable): RouteTable {
 export function createMatcherFromTable(
   tableImport: DehydratedRouteTable
 ): RouteMatcher {
-  return _createMatcher(createTableFromExport(tableImport));
+  return _createMatcher(_createTableFromExport(tableImport));
 }
 
 function _matchRoutes(path: string, table: RouteTable): RadixNodeData[] {

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -37,9 +37,7 @@ function _createRouteTable(): RouteTable {
   };
 }
 
-export function exportMatcherTable(
-  table: RouteTable
-): Record<"static" | "wildcard" | "dynamic", any> {
+export function exportMatcherTable(table: RouteTable): DehydratedRouteTable {
   const obj = Object.create(null);
 
   for (const property in table) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,8 +65,8 @@ export interface RadixRouter<T extends RadixNodeData = RadixNodeData> {
   remove(path: string): boolean;
 }
 
-export interface DehydratedRouteTable {
-  dynamic: Map<string, DehydratedRouteTable>;
+export interface MatcherExport {
+  dynamic: Map<string, MatcherExport>;
   wildcard: Map<string, { pattern: string }>;
   static: Map<string, { pattern: string }>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,7 +66,7 @@ export interface RadixRouter<T extends RadixNodeData = RadixNodeData> {
 }
 
 export interface DehydratedRouteTable {
-  dynamic: Map<string, DehydratedRouteTable>
-  wildcard: Map<string, { pattern: string }>
-  static: Map<string, { pattern: string }>
+  dynamic: Map<string, DehydratedRouteTable>;
+  wildcard: Map<string, { pattern: string }>;
+  static: Map<string, { pattern: string }>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,3 +64,9 @@ export interface RadixRouter<T extends RadixNodeData = RadixNodeData> {
    */
   remove(path: string): boolean;
 }
+
+export interface DehydratedRouteTable {
+  dynamic: Map<string, DehydratedRouteTable>
+  wildcard: Map<string, { pattern: string }>
+  static: Map<string, { pattern: string }>
+}

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { createRouter, exportMatcherTable, toRouteMatcher } from "../src";
+import { createRouter, exportMatcher, toRouteMatcher } from "../src";
 
 export function createRoutes(paths) {
   return Object.fromEntries(paths.map((path) => [path, { pattern: path }]));
@@ -143,7 +143,7 @@ describe("Route matcher", function () {
   });
 
   it("can be exported", () => {
-    const jsonData = exportMatcherTable(matcher.ctx.table);
+    const jsonData = exportMatcher(matcher);
     expect(jsonData).toMatchInlineSnapshot(`
       {
         "dynamic": {

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { createRouter, toRouteMatcher } from "../src";
+import { createRouter, exportMatcherTable, toRouteMatcher } from "../src";
 
 export function createRoutes(paths) {
   return Object.fromEntries(paths.map((path) => [path, { pattern: path }]));
@@ -141,4 +141,48 @@ describe("Route matcher", function () {
       ]
     `);
   });
+
+  it("can be exported", () => {
+    const jsonData = exportMatcherTable(matcher.ctx.table)
+    expect(jsonData).toMatchInlineSnapshot(`
+      {
+        "dynamic": {
+          "/foo": {
+            "dynamic": {},
+            "static": {
+              "/": {
+                "pattern": "/foo/*",
+              },
+              "/sub": {
+                "pattern": "/foo/*/sub",
+              },
+            },
+            "wildcard": {},
+          },
+        },
+        "static": {
+          "/": {
+            "pattern": "/",
+          },
+          "/foo": {
+            "pattern": "/foo",
+          },
+          "/foo/bar": {
+            "pattern": "/foo/bar",
+          },
+          "/foo/baz": {
+            "pattern": "/foo/baz",
+          },
+        },
+        "wildcard": {
+          "/foo": {
+            "pattern": "/foo/**",
+          },
+          "/foo/baz": {
+            "pattern": "/foo/baz/**",
+          },
+        },
+      }
+    `)
+  })
 });

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -143,7 +143,7 @@ describe("Route matcher", function () {
   });
 
   it("can be exported", () => {
-    const jsonData = exportMatcherTable(matcher.ctx.table)
+    const jsonData = exportMatcherTable(matcher.ctx.table);
     expect(jsonData).toMatchInlineSnapshot(`
       {
         "dynamic": {
@@ -183,6 +183,6 @@ describe("Route matcher", function () {
           },
         },
       }
-    `)
-  })
+    `);
+  });
 });


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This allows exporting route matchers directly from the table rather than having to regenerate them.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
