### PR TITLE
fix: use Map size to calculate the number of children

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -176,7 +176,7 @@ function remove(ctx: RadixRouterContext, path: string) {
   if (node.data) {
     const lastSection = sections.at(-1);
     node.data = null;
-    if (Object.keys(node.children).length === 0) {
+    if (node.children.size === 0) {
       const parentNode = node.parent;
       parentNode.children.delete(lastSection);
       parentNode.wildcardChildNode = null;

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -257,6 +257,19 @@ describe("Router remove", function () {
     });
   });
 
+  it("should be able to do something", function () {
+    const router = createRouter({
+      routes: createRoutes(["a/b", "a/b/:param1"]),
+    });
+
+    router.remove("a/b");
+    expect(router.lookup("a/b")).to.deep.equal(null);
+    expect(router.lookup("a/b/c")).to.deep.equal({
+      params: { param1: "c" },
+      path: "a/b/:param1",
+    });
+  });
+
   it("should be able to remove placeholder routes", function () {
     const router = createRouter({
       routes: createRoutes(["placeholder/:choo", "placeholder/:choo/:choo2"]),

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -257,7 +257,7 @@ describe("Router remove", function () {
     });
   });
 
-  it("does not remove child nodes when a non-leaf node is removed", function () {
+  it("removes data but does not delete a node if it has children", function () {
     const router = createRouter({
       routes: createRoutes(["a/b", "a/b/:param1"]),
     });

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -257,7 +257,7 @@ describe("Router remove", function () {
     });
   });
 
-  it("should be able to do something", function () {
+  it("does not remove child nodes when a non-leaf node is removed", function () {
     const router = createRouter({
       routes: createRoutes(["a/b", "a/b/:param1"]),
     });


### PR DESCRIPTION
fix: use Map `size` property to calculate the number of children. The current approach does not count them correctly

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/size

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

- The current approach to count the number of children that a node has is incorrect
- This means that calling `remove` will remove nodes that have no data, but do have children
- The intention is to remove nodes that have both no data and no children
- This uses the Map `size` property to count children correctly and align with the original intended behaviour

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
