### PR TITLE
fix(toRouteMatcher): respect non strict trailing slash

### DIFF
--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -19,13 +19,18 @@ export interface RouteMatcher {
 
 export function toRouteMatcher(router: RadixRouter): RouteMatcher {
   const table = _routerNodeToTable("", router.ctx.rootNode);
-  return _createMatcher(table);
+  return _createMatcher(table, !!router.ctx.options.strictTrailingSlash);
 }
 
-function _createMatcher(table: RouteTable): RouteMatcher {
+function _createMatcher(table: RouteTable, strictTrailingSlash: boolean): RouteMatcher {
   return {
     ctx: { table },
-    matchAll: (path) => _matchRoutes(path, table),
+    matchAll: (path) => {
+      if (!strictTrailingSlash && path.endsWith("/")) {
+        path = path.slice(0, -1) || "/";
+      }
+      return _matchRoutes(path, table)
+    },
   } satisfies RouteMatcher;
 }
 

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -19,18 +19,13 @@ export interface RouteMatcher {
 
 export function toRouteMatcher(router: RadixRouter): RouteMatcher {
   const table = _routerNodeToTable("", router.ctx.rootNode);
-  return _createMatcher(table, !!router.ctx.options.strictTrailingSlash);
+  return _createMatcher(table, router.ctx.options.strictTrailingSlash);
 }
 
-function _createMatcher(table: RouteTable, strictTrailingSlash: boolean): RouteMatcher {
+function _createMatcher(table: RouteTable, strictTrailingSlash?: boolean): RouteMatcher {
   return {
     ctx: { table },
-    matchAll: (path) => {
-      if (!strictTrailingSlash && path.endsWith("/")) {
-        path = path.slice(0, -1) || "/";
-      }
-      return _matchRoutes(path, table)
-    },
+    matchAll: (path: string) => _matchRoutes(path, table, strictTrailingSlash),
   } satisfies RouteMatcher;
 }
 
@@ -88,7 +83,12 @@ export function createMatcherFromExport(
   return _createMatcher(_createTableFromExport(matcherExport));
 }
 
-function _matchRoutes(path: string, table: RouteTable): RadixNodeData[] {
+function _matchRoutes(path: string, table: RouteTable, strictTrailingSlash?: boolean): RadixNodeData[] {
+  // By default trailing slashes are not strict
+  if (strictTrailingSlash !== true && path.endsWith("/")) {
+    path = path.slice(0, -1) || "/";
+  }
+
   // Order should be from less specific to most specific
   const matches = [];
 

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -22,7 +22,10 @@ export function toRouteMatcher(router: RadixRouter): RouteMatcher {
   return _createMatcher(table, router.ctx.options.strictTrailingSlash);
 }
 
-function _createMatcher(table: RouteTable, strictTrailingSlash?: boolean): RouteMatcher {
+function _createMatcher(
+  table: RouteTable,
+  strictTrailingSlash?: boolean,
+): RouteMatcher {
   return {
     ctx: { table },
     matchAll: (path: string) => _matchRoutes(path, table, strictTrailingSlash),
@@ -83,7 +86,11 @@ export function createMatcherFromExport(
   return _createMatcher(_createTableFromExport(matcherExport));
 }
 
-function _matchRoutes(path: string, table: RouteTable, strictTrailingSlash?: boolean): RadixNodeData[] {
+function _matchRoutes(
+  path: string,
+  table: RouteTable,
+  strictTrailingSlash?: boolean,
+): RadixNodeData[] {
   // By default trailing slashes are not strict
   if (strictTrailingSlash !== true && path.endsWith("/")) {
     path = path.slice(0, -1) || "/";

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -51,6 +51,8 @@ describe("Route matcher", function () {
     "/foo/baz",
     "/foo/baz/**",
     "/foo/*/sub",
+    "/without-trailing",
+    "/with-trailing/",
   ]);
 
   const router = createRouter({ routes });
@@ -87,6 +89,12 @@ describe("Route matcher", function () {
           },
           "/foo/baz" => {
             "pattern": "/foo/baz",
+          },
+          "/without-trailing" => {
+            "pattern": "/without-trailing",
+          },
+          "/with-trailing" => {
+            "pattern": "/with-trailing/",
           },
         },
         "wildcard": Map {
@@ -142,6 +150,26 @@ describe("Route matcher", function () {
     `);
   });
 
+  it("trailing slash", () => {
+    // Defined with trailing slash
+    expect(_match("/with-trailing")).to.toMatchInlineSnapshot(`
+      [
+        "/with-trailing/",
+      ]
+    `);
+    expect(_match("/with-trailing")).toMatchObject(_match("/with-trailing/"));
+
+    // Defined without trailing slash
+    expect(_match("/without-trailing")).to.toMatchInlineSnapshot(`
+      [
+        "/without-trailing",
+      ]
+    `);
+    expect(_match("/without-trailing")).toMatchObject(
+      _match("/without-trailing/"),
+    );
+  });
+
   it("can be exported", () => {
     const jsonData = exportMatcher(matcher);
     expect(jsonData).toMatchInlineSnapshot(`
@@ -172,6 +200,12 @@ describe("Route matcher", function () {
           },
           "/foo/baz": {
             "pattern": "/foo/baz",
+          },
+          "/with-trailing": {
+            "pattern": "/with-trailing/",
+          },
+          "/without-trailing": {
+            "pattern": "/without-trailing",
           },
         },
         "wildcard": {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves #87

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When creating router with default options, we _loose_ the trailing slash status as it is non strict by default.

`toRouteMatcher` when extending router should respect same options and when matching routes.

**Note:** This does not include `strictTrailingSlash` in the export object but by default we assume to have consistent default behavior (not sensitive to trailing slashes). For v2, we might include it in export object maybe with an `_*` key if needed. /cc @danielroe 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
