### PR TITLE
fix(matcher): avoid prefix overlap for wildcards

### DIFF
--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -101,7 +101,7 @@ function _matchRoutes(
 
   // Wildcard
   for (const [key, value] of _sortRoutesMap(table.wildcard)) {
-    if (path.startsWith(key)) {
+    if (path === key || path.startsWith(key + "/")) {
       matches.push(value);
     }
   }
@@ -139,7 +139,9 @@ function _routerNodeToTable(
         node.type === NODE_TYPES.NORMAL &&
         !(path.includes("*") || path.includes(":"))
       ) {
-        table.static.set(path, node.data);
+        if (node.data) {
+          table.static.set(path, node.data);
+        }
       } else if (node.type === NODE_TYPES.WILDCARD) {
         table.wildcard.set(path.replace("/**", ""), node.data);
       } else if (node.type === NODE_TYPES.PLACEHOLDER) {

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -53,6 +53,8 @@ describe("Route matcher", function () {
     "/foo/*/sub",
     "/without-trailing",
     "/with-trailing/",
+    "/c/**",
+    "/cart",
   ]);
 
   const router = createRouter({ routes });
@@ -96,6 +98,9 @@ describe("Route matcher", function () {
           "/with-trailing" => {
             "pattern": "/with-trailing/",
           },
+          "/cart" => {
+            "pattern": "/cart",
+          },
         },
         "wildcard": Map {
           "/foo" => {
@@ -103,6 +108,9 @@ describe("Route matcher", function () {
           },
           "/foo/baz" => {
             "pattern": "/foo/baz/**",
+          },
+          "/c" => {
+            "pattern": "/c/**",
           },
         },
       }
@@ -170,6 +178,19 @@ describe("Route matcher", function () {
     );
   });
 
+  it("prefix overlap", () => {
+    expect(_match("/c/123")).to.toMatchInlineSnapshot(`
+      [
+        "/c/**",
+      ]
+    `);
+    expect(_match("/cart")).to.toMatchInlineSnapshot(`
+      [
+        "/cart",
+      ]
+    `);
+  });
+
   it("can be exported", () => {
     const jsonData = exportMatcher(matcher);
     expect(jsonData).toMatchInlineSnapshot(`
@@ -192,6 +213,9 @@ describe("Route matcher", function () {
           "/": {
             "pattern": "/",
           },
+          "/cart": {
+            "pattern": "/cart",
+          },
           "/foo": {
             "pattern": "/foo",
           },
@@ -209,6 +233,9 @@ describe("Route matcher", function () {
           },
         },
         "wildcard": {
+          "/c": {
+            "pattern": "/c/**",
+          },
           "/foo": {
             "pattern": "/foo/**",
           },

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -184,6 +184,9 @@ describe("Route matcher", function () {
         "/c/**",
       ]
     `);
+    expect(_match("/c/123")).toMatchObject(_match("/c/123/"))
+    expect(_match("/c/123")).toMatchObject(_match("/c"))
+
     expect(_match("/cart")).to.toMatchInlineSnapshot(`
       [
         "/cart",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves #70

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR solves an issue with matcher that checked the segment without `/` prefix in wildcards.

`/foo/**` should match `/foo/`, `/foo/bar` and `/foo` but not `/foobar`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
