### PR TITLE
fix: consider max depth when multiple placeholders are candidate

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -113,7 +113,7 @@ function insert(ctx: RadixRouterContext, path: string, data: any) {
 
   let _unnamedPlaceholderCtr = 0;
 
-  const nodePath = [node];
+  const matchedNodes = [node];
 
   for (const section of sections) {
     let childNode: RadixNode<RadixNodeData> | undefined;
@@ -139,13 +139,13 @@ function insert(ctx: RadixRouterContext, path: string, data: any) {
         isStaticRoute = false;
       }
 
-      nodePath.push(childNode);
+      matchedNodes.push(childNode);
       node = childNode;
     }
   }
 
-  for (const [depth, node] of nodePath.entries()) {
-    node.maxDepth = Math.max(nodePath.length - depth, node.maxDepth || 0);
+  for (const [depth, node] of matchedNodes.entries()) {
+    node.maxDepth = Math.max(matchedNodes.length - depth, node.maxDepth || 0);
   }
 
   // Store whatever data was provided into the node

--- a/src/router.ts
+++ b/src/router.ts
@@ -189,7 +189,7 @@ function remove(ctx: RadixRouterContext, path: string) {
 function createRadixNode(options: Partial<RadixNode> = {}): RadixNode {
   return {
     type: options.type || NODE_TYPES.NORMAL,
-    depth: 0,
+    maxDepth: 0,
     parent: options.parent || null,
     children: new Map(),
     data: options.data || null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,12 +18,13 @@ export type MatchedRoute<T extends RadixNodeData = RadixNodeData> = Omit<
 
 export interface RadixNode<T extends RadixNodeData = RadixNodeData> {
   type: NODE_TYPE;
+  maxDepth: number;
   parent: RadixNode<T> | null;
   children: Map<string, RadixNode<T>>;
   data: RadixNodeData | null;
   paramName: string | null;
   wildcardChildNode: RadixNode<T> | null;
-  placeholderChildNode: RadixNode<T> | null;
+  placeholderChildren: RadixNode<T>[];
 }
 
 export interface RadixRouterOptions {

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -62,6 +62,40 @@ describe("Router lookup", function () {
         },
       },
     );
+
+    testRouter(["/", "/:a", "/:a/:y/:x/:b", "/:a/:x/:b", "/:a/:b"], {
+      "/": { path: "/" },
+      "/a": {
+        path: "/:a",
+        params: {
+          a: "a",
+        },
+      },
+      "/a/b": {
+        path: "/:a/:b",
+        params: {
+          a: "a",
+          b: "b",
+        },
+      },
+      "/a/x/b": {
+        path: "/:a/:x/:b",
+        params: {
+          a: "a",
+          b: "b",
+          x: "x",
+        },
+      },
+      "/a/y/x/b": {
+        path: "/:a/:y/:x/:b",
+        params: {
+          a: "a",
+          b: "b",
+          x: "x",
+          y: "y",
+        },
+      },
+    });
   });
 
   describe("should be able to perform wildcard lookups", function () {


### PR DESCRIPTION
resolves https://github.com/unjs/radix3/issues/95 (context: https://github.com/unjs/nitro/issues/2310)

The issue is original implementation considered there is one placeholder candidate on each level of tree (cached into `placeholderChildNode`). If there is more than one, we need to find the right candidate.

This PR fixes issue by assigning max depth to nodes when inserting and consider it when choosing the right candidate (it should have same remaining length of incoming request path)

(honestly this implementation is hacky, but for v1 we have no choice until fully rewrite in v2)