### PR TITLE
fix: align findAllRoutes with findRoute & compiled matchAll (#184)

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -156,6 +156,10 @@ function compileFinalMatch(
   let ret = `{data:${serializeData(ctx, data.data)}`;
 
   const conditions: string[] = [];
+  // Presence guards (segment-count checks) are not specificity constraints, so
+  // they must not raise `weight` — otherwise an optional `**` tail ties with a
+  // required `**:name` and the weight-sort/`unshift` ordering flips (#186).
+  let guardConditions = 0;
 
   // Add param properties
   const { paramsMap, paramsRegexp } = data;
@@ -169,6 +173,7 @@ function compileFinalMatch(
       } else if (lastParam[0] < 0 && paramsMap.length > 1) {
         // Optional `**` tail, but the required leading param(s) must be present
         conditions.push(`l>${currentIdx - 1}`);
+        guardConditions++;
       }
     }
     for (let i = 0; i < paramsRegexp.length; i++) {
@@ -195,7 +200,7 @@ function compileFinalMatch(
     (conditions.length > 0 ? `if(${conditions.join("&&")})` : "") +
     (ctx.opts?.matchAll ? `r.unshift(${ret}});` : `return ${ret}};`);
 
-  return { code, weight: conditions.length };
+  return { code, weight: conditions.length - guardConditions };
 }
 
 function compileNode(

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -161,9 +161,15 @@ function compileFinalMatch(
   const { paramsMap, paramsRegexp } = data;
   if (paramsMap && paramsMap.length > 0) {
     // Check for optional end parameters
-    const required = !paramsMap[paramsMap.length - 1][2] && currentIdx !== -1;
-    if (required) {
-      conditions.push(`l>${currentIdx}`);
+    const lastParam = paramsMap[paramsMap.length - 1];
+    if (currentIdx !== -1) {
+      if (!lastParam[2]) {
+        // Last segment is required (a param or a `**:name` wildcard)
+        conditions.push(`l>${currentIdx}`);
+      } else if (lastParam[0] < 0 && paramsMap.length > 1) {
+        // Optional `**` tail, but the required leading param(s) must be present
+        conditions.push(`l>${currentIdx - 1}`);
+      }
     }
     for (let i = 0; i < paramsRegexp.length; i++) {
       const regexp = paramsRegexp[i];

--- a/src/operations/find-all.ts
+++ b/src/operations/find-all.ts
@@ -71,12 +71,16 @@ function _findAll<T>(
         }
       }
     } else if (node.param.methods) {
-      // End of path: only an optional trailing param matches (e.g. `/*` matches `/`)
+      // End of path: only optional trailing params match (e.g. `/*` matches `/`).
+      // Filter per entry — one param node can hold both optional (`*`) and
+      // required (`:id`, `:id(\d+)`) routes (mirrors the wildcard branch above).
       const match = node.param.methods[method] || node.param.methods[""];
       if (match) {
-        const pMap = match[0].paramsMap;
-        if (pMap?.[pMap?.length - 1]?.[2] /* optional */) {
-          matches.push(...match);
+        for (const m of match) {
+          const pMap = m.paramsMap;
+          if (pMap?.[pMap.length - 1]?.[2] /* optional */) {
+            matches.push(m);
+          }
         }
       }
     }

--- a/src/operations/find-all.ts
+++ b/src/operations/find-all.ts
@@ -60,12 +60,22 @@ function _findAll<T>(
 
   // 2. Param
   if (node.param) {
-    _findAll(node.param, method, segments, index + 1, matches);
-    if (index === segments.length && node.param.methods) {
+    if (index < segments.length) {
+      // Consume this segment as the param, then validate regex constraints on
+      // the newly collected matches (mirrors `_lookupTree` in find.ts).
+      const start = matches.length;
+      _findAll(node.param, method, segments, index + 1, matches);
+      if (node.param.hasRegexParam) {
+        for (let r = matches.length - 1; r >= start; r--) {
+          if (matches[r].paramsRegexp[index]?.test(segment) === false) matches.splice(r, 1);
+        }
+      }
+    } else if (node.param.methods) {
+      // End of path: only an optional trailing param matches (e.g. `/*` matches `/`)
       const match = node.param.methods[method] || node.param.methods[""];
       if (match) {
         const pMap = match[0].paramsMap;
-        if (pMap?.[pMap?.length - 1]?.[2]) {
+        if (pMap?.[pMap?.length - 1]?.[2] /* optional */) {
           matches.push(...match);
         }
       }

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -14,8 +14,10 @@ describe("benchmark", () => {
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     console.log("bundle size", { bytes, gzipSize });
-    expect(bytes).toBeLessThanOrEqual(5800); // <5.8kb
-    expect(gzipSize).toBeLessThanOrEqual(2250); // <2.25kb
+    // Budget bumped from 5.8kb/2.25kb: findAllRoutes now validates regex param
+    // constraints and gates zero-segment param/wildcard matches (#184).
+    expect(bytes).toBeLessThanOrEqual(5900); // <5.9kb
+    expect(gzipSize).toBeLessThanOrEqual(2260); // <2.26kb
   });
 });
 

--- a/test/find-all.test.ts
+++ b/test/find-all.test.ts
@@ -279,6 +279,44 @@ describe("matcher: root path parity", () => {
   });
 });
 
+describe("matcher: regression #184", () => {
+  // `_findAllRoutes` asserts interpreter and compiled matchAll agree.
+
+  it("Bug A: regex-constrained param rejects non-matching segments", () => {
+    const router = createRouter(["/user/:id(\\d+)"]);
+    expect(_findAllRoutes(router, "GET", "/user/abc")).toEqual([]);
+    expect(_findAllRoutes(router, "GET", "/user/42")).toEqual(["/user/:id(\\d+)"]);
+  });
+
+  it("Bug A: unnamed regex group param is validated", () => {
+    const router = createRouter(["/(\\d+)"]);
+    expect(_findAllRoutes(router, "GET", "/abc")).toEqual([]);
+    expect(_findAllRoutes(router, "GET", "/42")).toEqual(["/(\\d+)"]);
+  });
+
+  it("Bug A: segment-wildcard param is validated", () => {
+    const router = createRouter(["/*.png"]);
+    expect(_findAllRoutes(router, "GET", "/logo.jpg")).toEqual([]);
+    expect(_findAllRoutes(router, "GET", "/logo.png")).toEqual(["/*.png"]);
+  });
+
+  it("Bug B: required param before a wildcard does not match zero segments", () => {
+    const router = createRouter(["/:id/**"]);
+    expect(_findAllRoutes(router, "GET", "/")).toEqual([]);
+    expect(_findAllRoutes(router, "GET", "")).toEqual([]);
+    expect(_findAllRoutes(router, "GET", "/a")).toEqual(["/:id/**"]);
+    expect(_findAllRoutes(router, "GET", "/a/b")).toEqual(["/:id/**"]);
+  });
+
+  it("Bug C: regex param before a wildcard does not crash on a short path", () => {
+    const router = createRouter(["/(\\d+)/**"]);
+    expect(_findAllRoutes(router, "GET", "/")).toEqual([]);
+    expect(_findAllRoutes(router, "GET", "/abc")).toEqual([]);
+    expect(_findAllRoutes(router, "GET", "/42")).toEqual(["/(\\d+)/**"]);
+    expect(_findAllRoutes(router, "GET", "/42/x")).toEqual(["/(\\d+)/**"]);
+  });
+});
+
 describe("matcher: named", () => {
   const router = createRouter(["/foo", "/foo/:bar", "/foo/:bar/:qaz"]);
 

--- a/test/find-all.test.ts
+++ b/test/find-all.test.ts
@@ -282,25 +282,25 @@ describe("matcher: root path parity", () => {
 describe("matcher: regression #184", () => {
   // `_findAllRoutes` asserts interpreter and compiled matchAll agree.
 
-  it("Bug A: regex-constrained param rejects non-matching segments", () => {
+  it("regex-constrained param rejects non-matching segments", () => {
     const router = createRouter(["/user/:id(\\d+)"]);
     expect(_findAllRoutes(router, "GET", "/user/abc")).toEqual([]);
     expect(_findAllRoutes(router, "GET", "/user/42")).toEqual(["/user/:id(\\d+)"]);
   });
 
-  it("Bug A: unnamed regex group param is validated", () => {
+  it("unnamed regex group param is validated", () => {
     const router = createRouter(["/(\\d+)"]);
     expect(_findAllRoutes(router, "GET", "/abc")).toEqual([]);
     expect(_findAllRoutes(router, "GET", "/42")).toEqual(["/(\\d+)"]);
   });
 
-  it("Bug A: segment-wildcard param is validated", () => {
+  it("segment-wildcard param is validated", () => {
     const router = createRouter(["/*.png"]);
     expect(_findAllRoutes(router, "GET", "/logo.jpg")).toEqual([]);
     expect(_findAllRoutes(router, "GET", "/logo.png")).toEqual(["/*.png"]);
   });
 
-  it("Bug B: required param before a wildcard does not match zero segments", () => {
+  it("required param before a wildcard does not match zero segments", () => {
     const router = createRouter(["/:id/**"]);
     expect(_findAllRoutes(router, "GET", "/")).toEqual([]);
     expect(_findAllRoutes(router, "GET", "")).toEqual([]);
@@ -308,7 +308,7 @@ describe("matcher: regression #184", () => {
     expect(_findAllRoutes(router, "GET", "/a/b")).toEqual(["/:id/**"]);
   });
 
-  it("Bug C: regex param before a wildcard does not crash on a short path", () => {
+  it("regex param before a wildcard does not crash on a short path", () => {
     const router = createRouter(["/(\\d+)/**"]);
     expect(_findAllRoutes(router, "GET", "/")).toEqual([]);
     expect(_findAllRoutes(router, "GET", "/abc")).toEqual([]);
@@ -328,7 +328,11 @@ describe("matcher: regression #184", () => {
     ]);
   });
 
-  it("optional `**` and required `**:name` on one node keep least→most order", () => {
+  // Regression #186: the optional-`**` presence guard (`l>currentIdx-1`) must
+  // not inflate the compiled match weight, or the compiler reorders the optional
+  // `**` sibling behind the required `**:name` and disagrees with the
+  // interpreter (which emits same-node siblings in insertion order).
+  it("optional `**` sibling is not reordered past required `**:name` (compiled)", () => {
     const router = createRouter(["/:id/**", "/:id/**:rest"]);
     expect(_findAllRoutes(router, "GET", "/a/b")).toEqual(["/:id/**", "/:id/**:rest"]);
     expect(_findAllRoutes(router, "GET", "/a/b/c")).toEqual(["/:id/**", "/:id/**:rest"]);

--- a/test/find-all.test.ts
+++ b/test/find-all.test.ts
@@ -315,6 +315,24 @@ describe("matcher: regression #184", () => {
     expect(_findAllRoutes(router, "GET", "/42")).toEqual(["/(\\d+)/**"]);
     expect(_findAllRoutes(router, "GET", "/42/x")).toEqual(["/(\\d+)/**"]);
   });
+
+  it("optional & required routes on one param node filter per entry", () => {
+    // A single param node can hold both an optional `*` and a required
+    // `:id`/`:id(\d+)` route; the end-of-path branch must filter each entry.
+    expect(_findAllRoutes(createRouter(["/foo/*", "/foo/:id"]), "GET", "/foo")).toEqual(["/foo/*"]);
+    // Reverse insertion order (required registered first) must still match `*`.
+    expect(_findAllRoutes(createRouter(["/foo/:id", "/foo/*"]), "GET", "/foo")).toEqual(["/foo/*"]);
+    // A required regex sibling must not be pushed (previously crashed in getMatchParams).
+    expect(_findAllRoutes(createRouter(["/foo/*", "/foo/:id(\\d+)"]), "GET", "/foo")).toEqual([
+      "/foo/*",
+    ]);
+  });
+
+  it("optional `**` and required `**:name` on one node keep least→most order", () => {
+    const router = createRouter(["/:id/**", "/:id/**:rest"]);
+    expect(_findAllRoutes(router, "GET", "/a/b")).toEqual(["/:id/**", "/:id/**:rest"]);
+    expect(_findAllRoutes(router, "GET", "/a/b/c")).toEqual(["/:id/**", "/:id/**:rest"]);
+  });
 });
 
 describe("matcher: named", () => {


### PR DESCRIPTION
Fixes #184.

`findAllRoutes` (`_findAll`) diverged from both `findRoute` and the compiled `matchAll` router in three related ways. All are fixed regression-first (failing tests added, confirmed failing, then fixed).

## Bugs fixed

- **Bug A — regex param constraints ignored.** `_findAll` never tested `paramsRegexp`, so a regex-constrained param (`:id(\d+)`, `*.png`, unnamed `(\d+)`) matched any single segment. The param branch now filters newly collected matches by `paramsRegexp[index]`, mirroring `_lookupTree` in `find.ts`.
- **Bug B — required param before a wildcard matched zero segments.** `/:id/**` matched `/` (and `""`) because the param branch recursed into `node.param` even at end of path. It now only recurses while a segment remains to consume.
- **Bug C — crash on a short path.** The same over-recursion with a regex param (`/(\d+)/**`) crashed in `getMatchParams` (`.match()` on a missing segment). Fixing B removes the crash.

## Compiler fix (bonus)

The dual-validation test surfaced that the **compiler had Bug B too** — contrary to the issue's assumption, compiled `matchAll` returned `["route"]` for `/:id/**` on `/`. `compileFinalMatch` only checked the last `paramsMap` entry, so an optional `**` tail masked a required leading param. It now emits `l>currentIdx-1` for an optional wildcard with leading params.

## Verification

- Regression tests added to `test/find-all.test.ts` (dual-validated against the compiler).
- Full suite green: 507 passing (137 pre-existing WPT expected-fails); types, lint, and format clean.
- Interpreter / `findRoute` / compiled `matchAll` now agree on every reproduction from the issue; Bug C no longer throws.

## Note on bundle budget

The added regex validation + segment-count gating pushed the core bundle 5755 → 5883 bytes, over the 5800 budget. After minimizing the new logic, the budget was bumped 5.8kb → 5.9kb (2.25 → 2.26kb gzip) with a justification comment — as the issue explicitly permits ("stay within it or justify any bump").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route matching for optional trailing segments and wildcard-style params, including stricter handling of regex-constrained parameters.
  * Fixed edge cases where matches could be incorrectly filtered or mis-ordered when optional `**` and required param variants coexist.
* **Tests**
  * Added regression coverage for matching/validation scenarios involving regex params, unnamed regex groups, wildcard interactions, and short/root paths to ensure interpreter and compiled results stay aligned.
* **Chores**
  * Updated bundle size benchmark thresholds slightly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->