### PR TITLE
fix(compiler): resolve method-agnostic fallback like runtime

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -131,24 +131,30 @@ function compileMethodMatch(
   currentIdx: number, // Set to -1 for non-param node
 ): string {
   let code = "";
+  let fallback = "";
   for (const key in methods) {
     const matchers = methods[key];
     if (matchers && matchers.length > 0) {
-      if (key !== "") code += `if(m==="${key}")${matchers.length > 1 ? "{" : ""}`;
       // Sort descending by weight and emit via `r.unshift`, so the final array
       // is least->most specific. `unshift` reverses emit order, so reverse
       // first to keep equal-weight siblings in insertion order (issue #187).
-      const _matchers = matchers
+      const body = matchers
         .map((m) => compileFinalMatch(ctx, m, currentIdx, params))
         .reverse()
-        .sort((a, b) => b.weight - a.weight);
-      for (const matcher of _matchers) {
-        code += matcher.code;
+        .sort((a, b) => b.weight - a.weight)
+        .map((m) => m.code)
+        .join("");
+      if (key === "") {
+        fallback = body;
+      } else {
+        code += `${code ? "else " : ""}if(m==="${key}"){${body}}`;
       }
-      if (key !== "") code += matchers.length > 1 ? "}" : "";
     }
   }
-  return code;
+  // Method-agnostic ("") entries are a fallback only — runtime resolves
+  // `methods[m] || methods[""]`, so a method-scoped entry shadows them even
+  // when its own conditions fail. Emit behind `else`, not unconditionally.
+  return fallback ? (code ? `${code}else{${fallback}}` : fallback) : code;
 }
 
 function compileFinalMatch(

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -114,16 +114,19 @@ function _optionalMatches<T>(
   method: string,
 ): MethodData<T>[] | undefined {
   const match = methods && (methods[method] || methods[""]);
-  if (match) {
-    const optional: MethodData<T>[] = [];
-    for (const m of match) {
-      const pMap = m.paramsMap;
-      if (pMap?.[pMap.length - 1]?.[2] /* optional */) {
-        optional.push(m);
+  if (!match) {
+    return;
+  }
+  let optional: MethodData<T>[] | undefined;
+  for (const m of match) {
+    const pMap = m.paramsMap;
+    if (pMap?.[pMap.length - 1]?.[2] /* optional */) {
+      // Single sibling needs no filtered copy (zero allocation)
+      if (match.length === 1) {
+        return match;
       }
-    }
-    if (optional.length > 0) {
-      return optional;
+      (optional ||= []).push(m);
     }
   }
+  return optional;
 }

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -60,25 +60,11 @@ function _lookupTree<T>(
       }
     }
     // Fallback to dynamic for last child (/test and /test/ matches /test/*)
-    if (node.param && node.param.methods) {
-      const match = node.param.methods[method] || node.param.methods[""];
-      if (match) {
-        const pMap = match[0].paramsMap;
-        if (pMap?.[pMap?.length - 1]?.[2] /* optional */) {
-          return match;
-        }
-      }
-    }
-    if (node.wildcard && node.wildcard.methods) {
-      const match = node.wildcard.methods[method] || node.wildcard.methods[""];
-      if (match) {
-        const pMap = match[0].paramsMap;
-        if (pMap?.[pMap?.length - 1]?.[2] /* optional */) {
-          return match;
-        }
-      }
-    }
-    return undefined;
+    return (
+      (node.param && _optionalMatches(node.param.methods, method)) ||
+      (node.wildcard && _optionalMatches(node.wildcard.methods, method)) ||
+      undefined
+    );
   }
 
   const segment = segments[index];
@@ -115,4 +101,29 @@ function _lookupTree<T>(
 
   // No match
   return;
+}
+
+/**
+ * Resolve a node's entries for the method and filter to those whose last param
+ * is optional (`*`, `**`) — one param/wildcard node can hold both required
+ * (`:id`, `**:name`) and optional routes, in any insertion order (mirrors
+ * findAllRoutes' per-entry filtering and the compiler's per-matcher guards).
+ */
+function _optionalMatches<T>(
+  methods: Record<string, MethodData<T>[] | undefined> | undefined,
+  method: string,
+): MethodData<T>[] | undefined {
+  const match = methods && (methods[method] || methods[""]);
+  if (match) {
+    const optional: MethodData<T>[] = [];
+    for (const m of match) {
+      const pMap = m.paramsMap;
+      if (pMap?.[pMap.length - 1]?.[2] /* optional */) {
+        optional.push(m);
+      }
+    }
+    if (optional.length > 0) {
+      return optional;
+    }
+  }
 }

--- a/test/.snapshot/compiled-all.mjs
+++ b/test/.snapshot/compiled-all.mjs
@@ -2,11 +2,17 @@
   let r = [];
   if (p.charCodeAt(p.length - 1) === 47) p = p.slice(0, -1);
   if (p === "/foo") {
-    if (m === "GET") r.unshift({ data: $0 });
+    if (m === "GET") {
+      r.unshift({ data: $0 });
+    }
   } else if (p === "/foo/bar") {
-    if (m === "GET") r.unshift({ data: $1 });
+    if (m === "GET") {
+      r.unshift({ data: $1 });
+    }
   } else if (p === "/foo/bar/baz") {
-    if (m === "GET") r.unshift({ data: $2 });
+    if (m === "GET") {
+      r.unshift({ data: $2 });
+    }
   }
   let s = p.split("/");
   if (s.length > 1 && s[s.length - 1] === "") s.pop();
@@ -16,13 +22,19 @@
       if (l > 3) {
         if (s[3] === "baz") {
           if (l === 4) {
-            if (m === "GET") r.unshift({ data: $3, params: { 0: s[2] } });
+            if (m === "GET") {
+              r.unshift({ data: $3, params: { 0: s[2] } });
+            }
           }
         }
       }
-      if (m === "GET") r.unshift({ data: $4, params: { _: s.slice(2).join("/") } });
+      if (m === "GET") {
+        r.unshift({ data: $4, params: { _: s.slice(2).join("/") } });
+      }
     }
   }
-  if (m === "GET") r.unshift({ data: $5, params: { _: s.slice(1).join("/") } });
+  if (m === "GET") {
+    r.unshift({ data: $5, params: { _: s.slice(1).join("/") } });
+  }
   return r;
 };

--- a/test/.snapshot/compiled-aot.mjs
+++ b/test/.snapshot/compiled-aot.mjs
@@ -16,19 +16,33 @@ const findRoute = /* @__PURE__ */ (() => {
   return (m, p) => {
     if (p.charCodeAt(p.length - 1) === 47) p = p.slice(0, -1);
     if (p === "/test") {
-      if (m === "GET") return { data: $0 };
+      if (m === "GET") {
+        return { data: $0 };
+      }
     } else if (p === "/test/foo") {
-      if (m === "GET") return { data: $1 };
+      if (m === "GET") {
+        return { data: $1 };
+      }
     } else if (p === "/test/foo/bar/qux") {
-      if (m === "GET") return { data: $2 };
+      if (m === "GET") {
+        return { data: $2 };
+      }
     } else if (p === "/test/foo/baz") {
-      if (m === "GET") return { data: $3 };
+      if (m === "GET") {
+        return { data: $3 };
+      }
     } else if (p === "/test/fooo") {
-      if (m === "GET") return { data: $4 };
+      if (m === "GET") {
+        return { data: $4 };
+      }
     } else if (p === "/another/path") {
-      if (m === "GET") return { data: $5 };
+      if (m === "GET") {
+        return { data: $5 };
+      }
     } else if (p === "/static:path/*/**") {
-      if (m === "GET") return { data: $6 };
+      if (m === "GET") {
+        return { data: $6 };
+      }
     }
     let s = p.split("/");
     if (s.length > 1 && s[s.length - 1] === "") s.pop();
@@ -38,26 +52,40 @@ const findRoute = /* @__PURE__ */ (() => {
         if (l > 2) {
           if (s[2] === "foo") {
             if (l === 4 || l === 3) {
-              if (m === "GET") return { data: $7, params: { 0: s[3] } };
+              if (m === "GET") {
+                return { data: $7, params: { 0: s[3] } };
+              }
             }
-            if (m === "GET") return { data: $8, params: { _: s.slice(3).join("/") } };
+            if (m === "GET") {
+              return { data: $8, params: { _: s.slice(3).join("/") } };
+            }
           }
         }
         if (l === 3 || l === 2) {
-          if (m === "GET") if (l > 2) return { data: $9, params: { id: s[2] } };
+          if (m === "GET") {
+            if (l > 2) return { data: $9, params: { id: s[2] } };
+          }
         } else if (s[3] === "y") {
           if (l === 4) {
-            if (m === "GET") return { data: $10, params: { idY: s[2] } };
+            if (m === "GET") {
+              return { data: $10, params: { idY: s[2] } };
+            }
           } else if (s[4] === "z") {
             if (l === 5) {
-              if (m === "GET") return { data: $11, params: { idYZ: s[2] } };
+              if (m === "GET") {
+                return { data: $11, params: { idYZ: s[2] } };
+              }
             }
           }
         }
       } else if (s[1] === "wildcard") {
-        if (m === "GET") return { data: $12, params: { _: s.slice(2).join("/") } };
+        if (m === "GET") {
+          return { data: $12, params: { _: s.slice(2).join("/") } };
+        }
       }
     }
-    if (m === "GET") return { data: $13, params: { _: s.slice(1).join("/") } };
+    if (m === "GET") {
+      return { data: $13, params: { _: s.slice(1).join("/") } };
+    }
   };
 })();

--- a/test/.snapshot/compiled-jit.mjs
+++ b/test/.snapshot/compiled-jit.mjs
@@ -1,19 +1,33 @@
 (m, p) => {
   if (p.charCodeAt(p.length - 1) === 47) p = p.slice(0, -1);
   if (p === "/test") {
-    if (m === "GET") return { data: $0 };
+    if (m === "GET") {
+      return { data: $0 };
+    }
   } else if (p === "/test/foo") {
-    if (m === "GET") return { data: $1 };
+    if (m === "GET") {
+      return { data: $1 };
+    }
   } else if (p === "/test/foo/bar/qux") {
-    if (m === "GET") return { data: $2 };
+    if (m === "GET") {
+      return { data: $2 };
+    }
   } else if (p === "/test/foo/baz") {
-    if (m === "GET") return { data: $3 };
+    if (m === "GET") {
+      return { data: $3 };
+    }
   } else if (p === "/test/fooo") {
-    if (m === "GET") return { data: $4 };
+    if (m === "GET") {
+      return { data: $4 };
+    }
   } else if (p === "/another/path") {
-    if (m === "GET") return { data: $5 };
+    if (m === "GET") {
+      return { data: $5 };
+    }
   } else if (p === "/static:path/*/**") {
-    if (m === "GET") return { data: $6 };
+    if (m === "GET") {
+      return { data: $6 };
+    }
   }
   let s = p.split("/");
   if (s.length > 1 && s[s.length - 1] === "") s.pop();
@@ -23,25 +37,39 @@
       if (l > 2) {
         if (s[2] === "foo") {
           if (l === 4 || l === 3) {
-            if (m === "GET") return { data: $7, params: { 0: s[3] } };
+            if (m === "GET") {
+              return { data: $7, params: { 0: s[3] } };
+            }
           }
-          if (m === "GET") return { data: $8, params: { _: s.slice(3).join("/") } };
+          if (m === "GET") {
+            return { data: $8, params: { _: s.slice(3).join("/") } };
+          }
         }
       }
       if (l === 3 || l === 2) {
-        if (m === "GET") if (l > 2) return { data: $9, params: { id: s[2] } };
+        if (m === "GET") {
+          if (l > 2) return { data: $9, params: { id: s[2] } };
+        }
       } else if (s[3] === "y") {
         if (l === 4) {
-          if (m === "GET") return { data: $10, params: { idY: s[2] } };
+          if (m === "GET") {
+            return { data: $10, params: { idY: s[2] } };
+          }
         } else if (s[4] === "z") {
           if (l === 5) {
-            if (m === "GET") return { data: $11, params: { idYZ: s[2] } };
+            if (m === "GET") {
+              return { data: $11, params: { idYZ: s[2] } };
+            }
           }
         }
       }
     } else if (s[1] === "wildcard") {
-      if (m === "GET") return { data: $12, params: { _: s.slice(2).join("/") } };
+      if (m === "GET") {
+        return { data: $12, params: { _: s.slice(2).join("/") } };
+      }
     }
   }
-  if (m === "GET") return { data: $13, params: { _: s.slice(1).join("/") } };
+  if (m === "GET") {
+    return { data: $13, params: { _: s.slice(1).join("/") } };
+  }
 };

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -21,12 +21,13 @@ describe("benchmark", () => {
     // +~15B: getParamRegexp() now escapes only literal dots *outside* (...) groups
     // so a `.` inside a regex constraint (`:id(\d+\.\d+)`) stays verbatim instead
     // of being double-escaped; gzip is unchanged (2383).
-    // -~67B raw / +~40B gzip: findRoute's end-of-path optional fallback now
+    // -~40B raw / +~50B gzip: findRoute's end-of-path optional fallback now
     // scans all same-node siblings (not just the first-inserted entry) via a
-    // shared helper — deduplication shrinks raw size, but the filter loop adds
-    // tokens the old duplicated blocks gzipped away.
+    // shared helper with a zero-allocation single-sibling fast path —
+    // deduplication shrinks raw size, but the filter loop adds tokens the old
+    // duplicated blocks gzipped away.
     expect(bytes).toBeLessThanOrEqual(6180); // <6.18kb
-    expect(gzipSize).toBeLessThanOrEqual(2425); // <2.43kb
+    expect(gzipSize).toBeLessThanOrEqual(2435); // <2.44kb
   });
 });
 

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -21,8 +21,12 @@ describe("benchmark", () => {
     // +~15B: getParamRegexp() now escapes only literal dots *outside* (...) groups
     // so a `.` inside a regex constraint (`:id(\d+\.\d+)`) stays verbatim instead
     // of being double-escaped; gzip is unchanged (2383).
-    expect(bytes).toBeLessThanOrEqual(6250); // <6.25kb
-    expect(gzipSize).toBeLessThanOrEqual(2385); // <2.39kb
+    // -~67B raw / +~40B gzip: findRoute's end-of-path optional fallback now
+    // scans all same-node siblings (not just the first-inserted entry) via a
+    // shared helper — deduplication shrinks raw size, but the filter loop adds
+    // tokens the old duplicated blocks gzipped away.
+    expect(bytes).toBeLessThanOrEqual(6180); // <6.18kb
+    expect(gzipSize).toBeLessThanOrEqual(2425); // <2.43kb
   });
 });
 

--- a/test/find-all.test.ts
+++ b/test/find-all.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { createRouter, formatTree } from "./_utils.ts";
-import { findAllRoutes, type RouterContext } from "../src/index.ts";
+import {
+  addRoute,
+  createRouter as createEmptyRouter,
+  findAllRoutes,
+  type RouterContext,
+} from "../src/index.ts";
 import { compileRouter } from "../src/compiler.ts";
 import { format } from "oxfmt";
 
@@ -368,6 +373,41 @@ describe("matcher: regression #187", () => {
       "/foo/:b",
       "/foo/:a",
     ]);
+  });
+});
+
+describe("matcher: method-agnostic fallback", () => {
+  // `_findAllRoutes` asserts interpreter and compiled matchAll agree.
+  // Runtime resolves `methods[m] || methods[""]` per node: a method-scoped
+  // registration fully shadows the method-agnostic one for that method. The
+  // compiled output must not emit both layers (duplicate agnostic layer bug).
+
+  it("method-scoped entry shadows the agnostic sibling on a wildcard node", () => {
+    const router = createEmptyRouter<{ path: string }>();
+    addRoute(router, "", "/api/**", { path: "AGN" });
+    addRoute(router, "GET", "/api/**", { path: "GET-DATA" });
+    expect(_findAllRoutes(router, "GET", "/api/x")).toEqual(["GET-DATA"]);
+    expect(_findAllRoutes(router, "POST", "/api/x")).toEqual(["AGN"]);
+  });
+
+  it("shadowing is independent of registration order", () => {
+    const router = createEmptyRouter<{ path: string }>();
+    addRoute(router, "GET", "/api/**", { path: "GET-DATA" });
+    addRoute(router, "", "/api/**", { path: "AGN" });
+    expect(_findAllRoutes(router, "GET", "/api/x")).toEqual(["GET-DATA"]);
+    expect(_findAllRoutes(router, "POST", "/api/x")).toEqual(["AGN"]);
+  });
+
+  it("static and param nodes shadow the same way", () => {
+    const router = createEmptyRouter<{ path: string }>();
+    addRoute(router, "", "/api", { path: "S-AGN" });
+    addRoute(router, "GET", "/api", { path: "S-GET" });
+    addRoute(router, "", "/api/:id", { path: "P-AGN" });
+    addRoute(router, "GET", "/api/:id", { path: "P-GET" });
+    expect(_findAllRoutes(router, "GET", "/api")).toEqual(["S-GET"]);
+    expect(_findAllRoutes(router, "POST", "/api")).toEqual(["S-AGN"]);
+    expect(_findAllRoutes(router, "GET", "/api/1")).toEqual(["P-GET"]);
+    expect(_findAllRoutes(router, "POST", "/api/1")).toEqual(["P-AGN"]);
   });
 });
 

--- a/test/find.test.ts
+++ b/test/find.test.ts
@@ -239,3 +239,29 @@ describe("method-agnostic fallback (compiled parity)", () => {
     });
   }
 });
+
+describe("end-of-path optional fallback with mixed same-node siblings", () => {
+  // One param/wildcard node can hold both required (`:id`, `**:name`) and
+  // optional (`*`, `**`) routes for the same method. The end-of-path fallback
+  // must scan all entries, not just the first-inserted one.
+  const router = createEmptyRouter<{ path: string }>();
+  addRoute(router, "GET", "/p/:id", { path: "P-REQUIRED" });
+  addRoute(router, "GET", "/p/*", { path: "P-OPTIONAL" });
+  addRoute(router, "GET", "/w/**:name", { path: "W-REQUIRED" });
+  addRoute(router, "GET", "/w/**", { path: "W-OPTIONAL" });
+  const compiledLookup = compileRouter(router);
+
+  const lookups = [
+    { name: "findRoute", match: (m: string, p: string) => findRoute(router, m, p) },
+    { name: "compiledLookup", match: (m: string, p: string) => compiledLookup(m, p) },
+  ];
+
+  for (const { name, match } of lookups) {
+    it(`optional sibling matches even when a required one was inserted first (${name})`, () => {
+      expect(match("GET", "/p")).toMatchObject({ data: { path: "P-OPTIONAL" } });
+      expect(match("GET", "/w")).toMatchObject({ data: { path: "W-OPTIONAL" } });
+      expect(match("GET", "/p/1")).toMatchObject({ data: { path: "P-REQUIRED" } });
+      expect(match("GET", "/w/1")).toMatchObject({ data: { path: "W-REQUIRED" } });
+    });
+  }
+});

--- a/test/find.test.ts
+++ b/test/find.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { createRouter, formatTree } from "./_utils.ts";
-import { findRoute, removeRoute } from "../src/index.ts";
+import {
+  addRoute,
+  createRouter as createEmptyRouter,
+  findRoute,
+  removeRoute,
+} from "../src/index.ts";
 import { compileRouter, compileRouterToString } from "../src/compiler.ts";
 import { format } from "oxfmt";
 
@@ -208,6 +213,29 @@ describe("hyphenated param names", () => {
       expect(match("GET", "/users/foo/bar")).not.toMatchObject({
         data: { path: "/users/:user-id" },
       });
+    });
+  }
+});
+
+describe("method-agnostic fallback (compiled parity)", () => {
+  // Runtime resolves `methods[m] || methods[""]` per node: when a
+  // method-scoped entry exists, the agnostic sibling is never consulted for
+  // that method — even if the scoped matcher's conditions (regex) fail.
+  const router = createEmptyRouter<{ path: string }>();
+  addRoute(router, "GET", "/x/:id(\\d+)", { path: "GET-DATA" });
+  addRoute(router, "", "/x/:id", { path: "AGN" });
+  const compiledLookup = compileRouter(router);
+
+  const lookups = [
+    { name: "findRoute", match: (m: string, p: string) => findRoute(router, m, p) },
+    { name: "compiledLookup", match: (m: string, p: string) => compiledLookup(m, p) },
+  ];
+
+  for (const { name, match } of lookups) {
+    it(`agnostic sibling is not a fallback for a failed method-scoped matcher (${name})`, () => {
+      expect(match("GET", "/x/42")).toMatchObject({ data: { path: "GET-DATA" } });
+      expect(match("GET", "/x/abc")).toBeUndefined();
+      expect(match("POST", "/x/abc")).toMatchObject({ data: { path: "AGN" } });
     });
   }
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routing fallback behavior so method-specific matches take precedence, and method-agnostic routes reliably apply only when appropriate.
  * Fixed end-of-path selection for optional parameter/wildcard routes so mixed required/optional siblings resolve correctly, with consistent results between interpreted and compiled routing.
* **Tests**
  * Added coverage for method-agnostic fallback/shadowing and end-of-path optional fallback across both interpreted and compiled lookups.
  * Updated compiled output snapshots for formatting consistency.
* **Chores**
  * Adjusted bundle size/gzip thresholds for the esbuild benchmark.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->