### PR TITLE
fix: canonicalize empty segments in route patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,15 @@ Param names accept `[\w-]+`, but a named capture group must be a valid identifie
 
 `normalizePath()` in `_utils.ts` resolves `.` and `..` segments in lookup paths (fast-path: skip if no `/.` found). Both `findRoute()` and `findAllRoutes()` normalize before matching. The compiler inlines equivalent logic in generated code.
 
+### Empty segments (trailing vs middle)
+
+Two different rules, and they must not be conflated:
+
+- **Trailing** empties are canonicalized away at **registration**: `add`/`remove` split patterns with `splitRoute()` (`splitPath()` + pop *all* remaining trailing empties), so `/a//` ≡ `/a/` ≡ `/a` (#193). `splitPath()` alone pops only one, which used to leave `/a//` as segments `["a", ""]` — the radix tree then matched only `/a///`, the `ctx.static` key was `/a/`, and the compiled static dispatch stripped to `/a`: three matchers, three answers. This mirrors the trailing-slash policy already documented for routes (`/a` ≡ `/a/`). Pinned in `find.test.ts` "route patterns with trailing empty segments (#193)".
+- **Lookup paths** are unchanged: `findRoute`/`findAllRoutes` slice one trailing `/` and `splitPath` pops one empty segment, so `/a//` reaches a `/a` route but `/a///` does not (a real empty segment remains). This bound is deliberate — `find.test.ts` "matches the static route for path//, **not beyond**" and the compiled static chain/map (which retries `p.slice(0,-1)` exactly once) both pin it. Do **not** turn `splitPath`'s `if` into a `while`.
+- **Middle** empties are *meaningful* and preserved everywhere: `/a//b` is a static segment `""` in the tree and matches only the doubled-slash path, never `/a/b` (request paths keep their empty segments too, so collapsing would create the classic normalization-mismatch bypass; URLPattern also treats `//` literally). `routeToRegExpSegments()` used to `continue` on every empty segment, so `routeToRegExp("/a//b")` emitted `^\/a\/b\/?$` — matching the one path the router won't and missing the one it will. It now splits with `splitRoute()` and re-emits middle empties. Pinned by the `/path//sub` + `/path//:id` fixtures in `_regexp-cases.ts` (which assert tree and regex agree) and `find.test.ts` "routes with an empty middle segment".
+- Known residual: an empty segment directly before a wildcard (`/a//**`, `/a//*`) still has the regex over-matching relative to the tree — the `**` emission makes its preceding separator optional (`\/\/?`), and lookup-side trailing normalization erases the empty segment in that position anyway. Pathological; not modeled.
+
 ### Wildcard segment captures
 
 - **Breaking change:** unnamed captures now use URLPattern-style numeric keys (`"0"`, `"1"`, ...) instead of legacy `_0`, `_1`, ...

--- a/src/operations/_utils.ts
+++ b/src/operations/_utils.ts
@@ -51,6 +51,13 @@ export function splitPath(path: string): string[] {
   return s;
 }
 
+/** Like `splitPath`, for route patterns: `/a//` and `/a/` canonicalize to `/a`. */
+export function splitRoute(path: string): string[] {
+  const s = splitPath(path);
+  while (s[s.length - 1] === "") s.pop();
+  return s;
+}
+
 export function getMatchParams(
   segments: string[],
   paramsMap: ParamsIndexMap,

--- a/src/operations/add.ts
+++ b/src/operations/add.ts
@@ -3,7 +3,7 @@ import { toGroupName, toUnnamedGroupKey } from "../_group-names.ts";
 import { hasSegmentWildcard, replaceSegmentWildcards } from "../_segment-wildcards.ts";
 import { NullProtoObj } from "../object.ts";
 import type { RouterContext, ParamsIndexMap } from "../types.ts";
-import { decodeEscaped, encodeEscapes, expandModifiers, splitPath } from "./_utils.ts";
+import { decodeEscaped, encodeEscapes, expandModifiers, splitRoute } from "./_utils.ts";
 
 /**
  * Add a route to the router context.
@@ -29,7 +29,7 @@ export function addRoute<T>(
 
   path = encodeEscapes(path);
 
-  const segments = splitPath(path);
+  const segments = splitRoute(path);
 
   // Expand modifiers (:name?, :name+, :name*) into multiple route entries
   const expanded = expandModifiers(segments);

--- a/src/operations/remove.ts
+++ b/src/operations/remove.ts
@@ -1,7 +1,7 @@
 import { expandGroupDelimiters } from "../_group-delimiters.ts";
 import { hasSegmentWildcard } from "../_segment-wildcards.ts";
 import type { RouterContext, Node } from "../types.ts";
-import { decodeEscaped, encodeEscapes, expandModifiers, splitPath } from "./_utils.ts";
+import { decodeEscaped, encodeEscapes, expandModifiers, splitRoute } from "./_utils.ts";
 
 /**
  * Remove a route from the router context.
@@ -17,7 +17,7 @@ export function removeRoute<T>(ctx: RouterContext<T>, method: string, path: stri
 
   path = encodeEscapes(path);
 
-  const segments = splitPath(path);
+  const segments = splitRoute(path);
 
   const modExpanded = expandModifiers(segments);
   if (modExpanded) {

--- a/src/regexp.ts
+++ b/src/regexp.ts
@@ -6,6 +6,7 @@ import {
   resolveEscapePlaceholders,
 } from "./_escape.ts";
 import { hasSegmentWildcard, replaceSegmentWildcards } from "./_segment-wildcards.ts";
+import { splitRoute } from "./operations/_utils.ts";
 
 /**
  * Convert a rou3 route pattern into an anchored {@link RegExp}.
@@ -26,6 +27,10 @@ import { hasSegmentWildcard, replaceSegmentWildcards } from "./_segment-wildcard
  * routeToRegExp("/blog/:id(\\d+){-:title}?"); // /^\/blog\/(?<id>\d+)(?:-(?<title>[^/]+))?\/?$/
  */
 export function routeToRegExp(route: string = "/"): RegExp {
+  if (route.charCodeAt(0) !== 47 /* '/' */) {
+    route = `/${route}`;
+  }
+
   // Compile a trailing single optional group (`{...}?`) inline as `(?:...)?`
   // instead of expanding it into an alternation of full routes. The alternation
   // form re-emits every param before the group in both branches, producing
@@ -129,8 +134,14 @@ function routeToRegExpSegments(route: string): string[] {
   const reSegments = [];
   let idCtr = 0;
 
-  for (const segment of route.split("/")) {
-    if (!segment) continue;
+  for (const segment of splitRoute(route)) {
+    // An empty *middle* segment (`/a//b`) is a real static segment in the tree,
+    // so it must stay in the regex; `splitRoute` has already dropped the leading
+    // and trailing empties (`/a//` = `/a/` = `/a`).
+    if (!segment) {
+      reSegments.push("");
+      continue;
+    }
 
     if (segment === "*") {
       reSegments.push(`(?<${toRegExpUnnamedKey(idCtr++)}>[^/]*)`);

--- a/test/_regexp-cases.ts
+++ b/test/_regexp-cases.ts
@@ -30,6 +30,19 @@ export const regexpCases: Record<string, RegExpCase> = {
       ["/path//foo/", { "0": "" }],
     ],
   },
+  // An empty *middle* segment is a real segment: the radix tree gives it a
+  // static node, so `/path//sub` matches only the doubled-slash path and never
+  // `/path/sub`. The regex must agree (it used to drop empty segments, emitting
+  // `^\/path\/sub\/?$` — matching the one path the router won't, and missing the
+  // one it will). Only *trailing* empties are canonicalized away (`/a//` = `/a`).
+  "/path//sub": {
+    regex: /^\/path\/\/sub\/?$/,
+    match: [["/path//sub"], ["/path//sub/"]],
+  },
+  "/path//:id": {
+    regex: /^\/path\/\/(?<id>[^/]+)\/?$/,
+    match: [["/path//value", { id: "value" }]],
+  },
   "/path/*.png": {
     regex: /^\/path\/(?<_0>[^/]*)\.png\/?$/,
     match: [["/path/icon.png", { "0": "icon" }]],

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -47,8 +47,14 @@ describe("benchmark", () => {
     // aren't (`-`, leading digit) into a reserved injective form and decodes
     // them back when groups are read — `:file-name.json` / `:id(\d+)` with such
     // a name used to throw `SyntaxError: Invalid capture group name` at addRoute.
-    expect(bytes).toBeLessThanOrEqual(6580); // <6.58kb
-    expect(gzipSize).toBeLessThanOrEqual(2670); // <2.67kb
+    // +~56B raw / +~13B gzip: addRoute/removeRoute split route patterns with
+    // splitRoute(), which drops *all* trailing empty segments, so `/a//` is
+    // registered as `/a` (#193). Keeping just one (splitPath) left the tree, the
+    // ctx.static key and the compiled static dispatch each matching a different
+    // set of paths. Lookup paths still use splitPath (one popped empty segment,
+    // i.e. `/a//` reaches `/a` but `/a///` does not) — unchanged.
+    expect(bytes).toBeLessThanOrEqual(6640); // <6.64kb
+    expect(gzipSize).toBeLessThanOrEqual(2690); // <2.69kb
   });
 });
 

--- a/test/find.test.ts
+++ b/test/find.test.ts
@@ -6,6 +6,7 @@ import {
   findAllRoutes,
   findRoute,
   removeRoute,
+  routeToRegExp,
 } from "../src/index.ts";
 import { compileRouter, compileRouterToString } from "../src/compiler.ts";
 import { format } from "oxfmt";
@@ -672,6 +673,61 @@ describe("static routes reached with a doubled trailing slash (compiled parity)"
       }
     });
   }
+});
+
+describe("route patterns with trailing empty segments (#193)", () => {
+  // A route registered as "/a//" used to keep a trailing empty segment, so the
+  // radix tree ("/a///"), the ctx.static key ("/a/") and the compiled static
+  // dispatch ("/a") each matched a different set of paths. Trailing slashes are
+  // already "don't care" for routes (/a === /a/), so the extras fold in too:
+  // /a// registers exactly as /a. Middle empties stay meaningful (see "/a//b").
+  for (const route of ["/a", "/a/", "/a//", "/a///"]) {
+    const router = createEmptyRouter<{ route: string }>();
+    addRoute(router, "GET", route, { route });
+    const compiledLookup = compileRouter(router);
+    const compiledMatchAll = compileRouter(router, { matchAll: true });
+
+    it(`route "${route}" matches /a, /a/ and /a// in every matcher`, () => {
+      for (const path of ["/a", "/a/", "/a//"]) {
+        expect(findRoute(router, "GET", path), `findRoute ${path}`).toMatchObject({
+          data: { route },
+        });
+        expect(compiledLookup("GET", path), `compiled ${path}`).toMatchObject({ data: { route } });
+        expect(findAllRoutes(router, "GET", path).map((m) => m.data.route)).toEqual([route]);
+        expect(compiledMatchAll("GET", path).map((m) => m.data.route)).toEqual([route]);
+      }
+      // beyond the doubled slash a real empty segment remains -> no match
+      expect(findRoute(router, "GET", "/a///")).toBeUndefined();
+      expect(compiledLookup("GET", "/a///")).toBeUndefined();
+    });
+
+    it(`route "${route}" is removable by its registered form`, () => {
+      const r = createEmptyRouter<{ route: string }>();
+      addRoute(r, "GET", route, { route });
+      removeRoute(r, "GET", route);
+      expect(findRoute(r, "GET", "/a")).toBeUndefined();
+    });
+  }
+});
+
+describe("routes with an empty middle segment", () => {
+  // Unlike trailing empties, an empty segment inside the path is a real static
+  // segment (the request path keeps it too), so "/a//b" must not answer "/a/b".
+  const router = createEmptyRouter<{ route: string }>();
+  addRoute(router, "GET", "/a//b", { route: "/a//b" });
+  const compiledLookup = compileRouter(router);
+
+  it("matches only the doubled-slash path", () => {
+    for (const match of [
+      (p: string) => findRoute(router, "GET", p),
+      (p: string) => compiledLookup("GET", p),
+    ]) {
+      expect(match("/a//b")).toMatchObject({ data: { route: "/a//b" } });
+      expect(match("/a/b")).toBeUndefined();
+    }
+    expect(routeToRegExp("/a//b").test("/a//b")).toBe(true);
+    expect(routeToRegExp("/a//b").test("/a/b")).toBe(false);
+  });
 });
 
 describe("same-node sibling selection (findRoute/compiled parity)", () => {


### PR DESCRIPTION
Closes #193.

Two empty-segment rules were tangled together. This separates them:

**Trailing empties are canonicalized away at registration.** `addRoute`/`removeRoute` now split patterns with `splitRoute()` (`splitPath()` plus a pop of *any* remaining trailing empties), so `/a//` ≡ `/a/` ≡ `/a`. `splitPath()` pops only one, which left `/a//` as segments `["a", ""]` — the radix tree then matched only `/a///`, the `ctx.static` key was `/a/`, and the compiled static dispatch stripped to `/a`. Three matchers, three answers, with `findRoute` and `findAllRoutes` disagreeing inside the interpreter itself. Trailing slashes are already "don't care" for routes (`/a` ≡ `/a/`), so the extras just fold into that.

Lookup paths are **unchanged**: `findRoute`/`findAllRoutes` slice one trailing `/` and `splitPath` pops one empty segment, so `/a//` still reaches a `/a` route and `/a///` still does not. That bound is deliberate (`find.test.ts` → "matches the static route for path//, not beyond", plus the compiled static chain/map retrying `p.slice(0,-1)` exactly once); widening it would let a request with `//` silently reach a handler registered without it, which is the classic normalization-mismatch bypass.

**Empty middle segments are meaningful and are now preserved in `routeToRegExp`.** `/a//b` is a real static `""` segment in the tree — request paths keep their empty segments, and URLPattern treats `//` literally too — so it matches only the doubled-slash path. But `routeToRegExpSegments()` skipped every empty segment, emitting `^\/a\/b\/?$`: it matched the one path the router won't (`/a/b`) and missed the one it will (`/a//b`). It now splits with the same `splitRoute()` and re-emits middle empties. `regExpToRoute()` already parsed `\/\/` correctly and round-trips.

| route | path | findRoute | compiled | routeToRegExp |
|---|---|---|---|---|
| `/a//b` | `/a//b` | ✅ | ✅ | ✅ (was ❌) |
| `/a//b` | `/a/b` | ❌ | ❌ | ❌ (was ✅) |
| `/a//` | `/a`, `/a/`, `/a//` | ✅ (was ❌/❌/✅) | ✅ | ✅ |

### Tests

Regression-first — all confirmed failing before the fix:

- `find.test.ts` → "route patterns with trailing empty segments (#193)": each of `/a`, `/a/`, `/a//`, `/a///` registers identically, matches in all four matchers, and is removable by its registered form.
- `find.test.ts` → "routes with an empty middle segment": tree, compiled and regex all reject `/a/b` for route `/a//b`.
- `_regexp-cases.ts` → `/path//sub`, `/path//:id` fixtures, which feed `regexp.test.ts` (asserts `findRoute` and the regex agree on the same paths), the PCRE cross-engine suite, and the `regExpToRoute` round-trip.

Bundle budget moves 6580 → 6640 B (2670 → 2690 gzip). The +56 B is entirely `splitRoute` in the core bundle; `regexp.ts` is tree-shaken out of that measurement.

### Known residual (documented in AGENTS.md, not fixed here)

An empty segment directly before a wildcard (`/a//**`, `/a//*`) still has the regex over-matching relative to the tree: the `**` emission deliberately makes its preceding separator optional (`\/\/?`), and lookup-side trailing normalization erases an empty segment in that position anyway. Strictly better than before, but not exact. Happy to model it properly if you'd rather not ship the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Route patterns now consistently handle trailing slashes and empty trailing segments.
  * Empty segments within a route are preserved, so paths such as `/a//b` match only their exact structure.
  * Route registration, lookup, removal, and compiled matching now use consistent path normalization.
  * Routes can be converted to matchers correctly whether or not the leading slash is provided.

* **Tests**
  * Added coverage for trailing-slash equivalence and meaningful middle empty segments.
  * Updated bundle-size limits to reflect the improved routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->