### PR TITLE
fix: merge sibling placeholders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,13 @@ on:
       - main
       - v1
       - v2
+      - radix3
   pull_request:
     branches:
       - main
       - v1
       - v2
+      - radix3
 
 jobs:
   ci:

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -128,6 +128,33 @@ function _sortRoutesMap(m: Map<string, any>) {
   return [...m.entries()].sort((a, b) => a[0].length - b[0].length);
 }
 
+function _mergeRouteTables(a: RouteTable, b: RouteTable): RouteTable {
+  const merged = _createRouteTable();
+  for (const [key, value] of a.static) {
+    merged.static.set(key, value);
+  }
+  for (const [key, value] of b.static) {
+    merged.static.set(key, value);
+  }
+  for (const [key, value] of a.wildcard) {
+    merged.wildcard.set(key, value);
+  }
+  for (const [key, value] of b.wildcard) {
+    merged.wildcard.set(key, value);
+  }
+  for (const [key, value] of a.dynamic) {
+    merged.dynamic.set(key, value);
+  }
+  for (const [key, value] of b.dynamic) {
+    const existing = merged.dynamic.get(key);
+    merged.dynamic.set(
+      key,
+      existing ? _mergeRouteTables(existing, value) : value,
+    );
+  }
+  return merged;
+}
+
 function _routerNodeToTable(
   initialPath: string,
   initialNode: RadixNode,
@@ -149,7 +176,14 @@ function _routerNodeToTable(
         if (node.data) {
           subTable.static.set("/", node.data);
         }
-        table.dynamic.set(path.replace(/\/\*|\/:\w+/, ""), subTable);
+        // Sibling placeholders share the same dynamic key so we need
+        // to merge them for shorter patterns to remain matchable.
+        const key = path.replace(/\/\*|\/:\w+/, "");
+        const existing = table.dynamic.get(key);
+        table.dynamic.set(
+          key,
+          existing ? _mergeRouteTables(existing, subTable) : subTable,
+        );
         return;
       }
     }

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -51,6 +51,8 @@ describe("Route matcher", function () {
     "/foo/baz",
     "/foo/baz/**",
     "/foo/*/sub",
+    "/:foo/qux",
+    "/:bar/quux",
     "/without-trailing",
     "/with-trailing/",
     "/c/**",
@@ -74,6 +76,18 @@ describe("Route matcher", function () {
               },
               "/" => {
                 "pattern": "/foo/*",
+              },
+            },
+            "wildcard": Map {},
+          },
+          "" => {
+            "dynamic": Map {},
+            "static": Map {
+              "/qux" => {
+                "pattern": "/:foo/qux",
+              },
+              "/quux" => {
+                "pattern": "/:bar/quux",
               },
             },
             "wildcard": Map {},
@@ -156,6 +170,16 @@ describe("Route matcher", function () {
         "/foo/*",
       ]
     `);
+    expect(_match("/123/qux")).to.toMatchInlineSnapshot(`
+      [
+        "/:foo/qux",
+      ]
+    `);
+    expect(_match("/123/quux")).to.toMatchInlineSnapshot(`
+      [
+        "/:bar/quux",
+      ]
+    `);
   });
 
   it("trailing slash", () => {
@@ -199,6 +223,18 @@ describe("Route matcher", function () {
     expect(jsonData).toMatchInlineSnapshot(`
       {
         "dynamic": {
+          "": {
+            "dynamic": {},
+            "static": {
+              "/quux": {
+                "pattern": "/:bar/quux",
+              },
+              "/qux": {
+                "pattern": "/:foo/qux",
+              },
+            },
+            "wildcard": {},
+          },
           "/foo": {
             "dynamic": {},
             "static": {

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -51,8 +51,9 @@ describe("Route matcher", function () {
     "/foo/baz",
     "/foo/baz/**",
     "/foo/*/sub",
-    "/:foo/qux",
-    "/:bar/quux",
+    "/*/qux",
+    "/:foo/quux",
+    "/:bar/corge",
     "/without-trailing",
     "/with-trailing/",
     "/c/**",
@@ -84,10 +85,13 @@ describe("Route matcher", function () {
             "dynamic": Map {},
             "static": Map {
               "/qux" => {
-                "pattern": "/:foo/qux",
+                "pattern": "/*/qux",
               },
               "/quux" => {
-                "pattern": "/:bar/quux",
+                "pattern": "/:foo/quux",
+              },
+              "/corge" => {
+                "pattern": "/:bar/corge",
               },
             },
             "wildcard": Map {},
@@ -172,12 +176,17 @@ describe("Route matcher", function () {
     `);
     expect(_match("/123/qux")).to.toMatchInlineSnapshot(`
       [
-        "/:foo/qux",
+        "/*/qux",
       ]
     `);
     expect(_match("/123/quux")).to.toMatchInlineSnapshot(`
       [
-        "/:bar/quux",
+        "/:foo/quux",
+      ]
+    `);
+    expect(_match("/123/corge")).to.toMatchInlineSnapshot(`
+      [
+        "/:bar/corge",
       ]
     `);
   });
@@ -226,11 +235,14 @@ describe("Route matcher", function () {
           "": {
             "dynamic": {},
             "static": {
+              "/corge": {
+                "pattern": "/:bar/corge",
+              },
               "/quux": {
-                "pattern": "/:bar/quux",
+                "pattern": "/:foo/quux",
               },
               "/qux": {
-                "pattern": "/:foo/qux",
+                "pattern": "/*/qux",
               },
             },
             "wildcard": {},


### PR DESCRIPTION
Hey 👋

> [!NOTE]
> If contributions against radix3 aren't welcome anymore, please simply ignore and close 🙏
> (I'm sorry I couldn't find any notice about that)

Fixes: https://github.com/nuxt/nuxt/issues/34715 *(radix3 > nitro 2 > nuxt 4)*

### What's the issue

When one declares the following routes:
```
/*/qux
/:foo/quux
/:bar/corge
```

Only the last one makes it to the route table.

### Why it's happening

This happens because `*`, `:foo`, and `:bar` all get normalized by the matcher to `''`. The last node to be added then overwrites any previous entry instead of being merged against them: https://github.com/h3js/rou3/blob/915745710aebebf539b78a20228f0d229974ccc3/src/matcher.ts#L147-L153

This CI run with just the added tests illustrates the issue: https://github.com/lihbr/rou3/actions/runs/29713252033/job/88260860557?pr=1 (ignore the `param pattern overlap (nuxt/nuxt#34715)` suite I removed from this PR)

### How to fix it

This can be fixed by merging the existing subtable with the new subtable.

I believe the added work shouldn't impact performances as it happens when building the table, not at resolution time(?)

### Why it matters

Normally, one wouldn't declare the above routes. Instead, they'd declare (either programatically or via folder structure in downstream frameworks doing file-based routing):
```
/*/qux
/*/quux
/*/corge
```

However, on i18n websites, the following structure is more likely to happen:
```
/:slug/about
/:lang/:slug/about
```

In such cases, only the last one makes it to the route table.

---

On Nuxt 4, this doesn't impact the frontend routing itself (as it's handled by Vue router, not radix3), however, when generating routes for Nuxt's `*/_payload.json` this surfaces the issue ([see this reproduction for all cases](https://stackblitz.com/edit/github-cuslcowg?file=README.md)):
```bash
/:slug/about                     # ✅ through Vue router
/:slug/about/_payload.json       # ❌ overriden
/:lang/:slug/about               # ✅ through Vue router
/:lang/:slug/about/_payload.json # ✅ win because it's last declared/longer(?)
```

### Does this also impact rou3

[I confirmed rou3 is not impacted](https://github.com/nuxt/nuxt/issues/34715#issuecomment-5016048293), tests seem to already cover such cases: https://github.com/h3js/rou3/blob/39b0e9b79585cea3871629a2aa23d4e693b276fb/test/router.test.ts#L186-L187
Happy to add targeted tests towards i18n pattern in rou3 in another PR if you'd like to :)

*Let me know if anything, thanks!*